### PR TITLE
Add pre-commit hooks configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,405 @@
+---
+fail_fast: true
+
+# We use system Python, with required dependencies specified in pyproject.toml.
+# We therefore cannot use those dependencies in pre-commit CI.
+ci:
+  skip:
+    - actionlint
+    - check-manifest
+    - deptry
+    - doc8
+    - pydocstringformatter
+    - docs
+    - interrogate
+    - interrogate-docs
+    - linkcheck
+    - mypy
+    - mypy-docs
+    - pylint
+    - pyproject-fmt-fix
+    - pyright
+    - pyright-docs
+    - pyright-verifytypes
+    - ty
+    - ty-docs
+    - pyrefly
+    - pyrefly-docs
+    - pyroma
+    - ruff-check-fix
+    - ruff-check-fix-docs
+    - ruff-format-fix
+    - ruff-format-fix-docs
+    - shellcheck
+    - shellcheck-docs
+    - shfmt
+    - shfmt-docs
+    - spelling
+    - sphinx-lint
+    - vulture
+    - vulture-docs
+    - yamlfix
+    - zizmor
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+default_install_hook_types: [pre-commit, pre-push]
+
+repos:
+  - repo: meta
+    hooks:
+      - id: check-useless-excludes
+        stages: [pre-commit]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        stages: [pre-commit]
+      - id: check-case-conflict
+        stages: [pre-commit]
+      - id: check-executables-have-shebangs
+        stages: [pre-commit]
+      - id: check-merge-conflict
+        stages: [pre-commit]
+      - id: check-shebang-scripts-are-executable
+        stages: [pre-commit]
+      - id: check-symlinks
+        stages: [pre-commit]
+      - id: check-json
+        stages: [pre-commit]
+      - id: check-toml
+        stages: [pre-commit]
+      - id: check-vcs-permalinks
+        stages: [pre-commit]
+      - id: check-yaml
+        stages: [pre-commit]
+      - id: end-of-file-fixer
+        stages: [pre-commit]
+      - id: file-contents-sorter
+        files: spelling_private_dict\.txt$
+        stages: [pre-commit]
+      - id: trailing-whitespace
+        stages: [pre-commit]
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-directive-colons
+        stages: [pre-commit]
+      - id: rst-inline-touching-normal
+        stages: [pre-commit]
+      - id: text-unicode-replacement-char
+        stages: [pre-commit]
+      - id: rst-backticks
+
+        stages: [pre-commit]
+  - repo: local
+    hooks:
+      - id: actionlint
+        name: actionlint
+        entry: uv run --extra=dev actionlint
+        language: python
+        pass_filenames: false
+        types_or: [yaml]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: pydocstringformatter
+        name: pydocstringformatter
+        entry: uv run --extra=dev pydocstringformatter
+        language: python
+        types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: shellcheck
+        name: shellcheck
+        entry: uv run --extra=dev shellcheck --shell=bash
+        language: python
+        types_or: [shell]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: shellcheck-docs
+        name: shellcheck-docs
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell
+          --language=console --command="shellcheck --shell=bash"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: shfmt
+        name: shfmt
+        entry: shfmt --write --space-redirects --indent=4
+        language: python
+        types_or: [shell]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: shfmt-docs
+        name: shfmt-docs
+        entry: uv run --extra=dev doccmd --language=shell --language=console --skip-marker=shfmt
+          --no-pad-file --command="shfmt --write --space-redirects --indent=4"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: mypy
+        name: mypy
+        stages: [pre-push]
+        entry: uv run --extra=dev -m mypy
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
+      - id: mypy-docs
+        name: mypy-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        language: python
+        types_or: [markdown, rst]
+
+      - id: check-manifest
+        name: check-manifest
+        stages: [pre-push]
+        entry: uv run --extra=dev -m check_manifest
+        language: python
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pyright
+        name: pyright
+        stages: [pre-push]
+        entry: uv run --extra=dev -m pyright .
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pyright-docs
+        name: pyright-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pyright"
+        language: python
+        types_or: [markdown, rst]
+
+      - id: pyright-verifytypes
+        name: pyright-verifytypes
+        stages: [pre-push]
+        entry: uv run --extra=dev -m pyright --ignoreexternal --verifytypes sphinx_literalizer
+        language: python
+        pass_filenames: false
+        types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty
+        name: ty
+        stages: [pre-push]
+        entry: uv run --extra=dev ty check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty-docs
+        name: ty-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="ty check"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pyrefly
+        name: pyrefly
+        stages: [pre-push]
+        entry: uv run --extra=dev pyrefly check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pyrefly-docs
+        name: pyrefly-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pyrefly check"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: vulture
+        name: vulture
+        entry: uv run --extra=dev -m vulture .
+        language: python
+        types_or: [python]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: vulture-docs
+        name: vulture docs
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="vulture"
+        language: python
+        types_or: [python]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: pyroma
+        name: pyroma
+        entry: uv run --extra=dev -m pyroma --min 10 .
+        language: python
+        pass_filenames: false
+        types_or: [toml]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: deptry
+        name: deptry
+        entry: uv run --extra=dev -m deptry src/
+        language: python
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: pylint
+        name: pylint
+        entry: uv run --extra=dev -m pylint *.py src/ tests/ docs/
+        language: python
+        stages: [manual]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: pylint-docs
+        name: pylint-docs
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pylint"
+        language: python
+        stages: [manual]
+        types_or: [markdown, rst]
+
+      - id: ruff-check-fix
+        name: Ruff check fix
+        entry: uv run --extra=dev -m ruff check --fix
+        language: python
+        types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: ruff-check-fix-docs
+        name: Ruff check fix docs
+        entry: uv run --extra=dev doccmd --language=python --command="ruff check --fix"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: ruff-format-fix
+        name: Ruff format
+        entry: uv run --extra=dev -m ruff format
+        language: python
+        types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: ruff-format-fix-docs
+        name: Ruff format docs
+        entry: uv run --extra=dev doccmd --language=python --no-pad-file --command="ruff
+          format"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: doc8
+        name: doc8
+        entry: uv run --extra=dev -m doc8
+        language: python
+        types_or: [rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: interrogate
+        name: interrogate
+        entry: uv run --extra=dev -m interrogate
+        language: python
+        types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: interrogate-docs
+        name: interrogate docs
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="interrogate"
+        language: python
+        types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: pyproject-fmt-fix
+        name: pyproject-fmt
+        entry: uv run --extra=dev pyproject-fmt
+        language: python
+        types_or: [toml]
+        files: pyproject.toml
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: linkcheck
+        name: linkcheck
+        entry: uv run --extra=dev sphinx-build -M linkcheck docs/source docs/build
+          -W
+        language: python
+        types_or: [rst]
+        stages: [manual]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: spelling
+        name: spelling
+        entry: uv run --extra=dev sphinx-build -M spelling docs/source docs/build
+          -W
+        language: python
+        types_or: [rst]
+        stages: [manual]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: docs
+        name: Build Documentation
+        entry: uv run --extra=dev sphinx-build -M html docs/source docs/build -W
+        language: python
+        stages: [manual]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: yamlfix
+        name: pyproject-fmt
+        entry: uv run --extra=dev yamlfix
+        language: python
+        types_or: [yaml]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: zizmor
+        name: zizmor
+        entry: uv run --extra=dev zizmor --strict-collection .github
+        language: python
+        pass_filenames: false
+        types_or: [yaml]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]
+
+      - id: sphinx-lint
+        name: sphinx-lint
+        entry: uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long
+        language: python
+        types_or: [rst]
+        additional_dependencies: [uv==0.9.5]
+        stages: [pre-commit]


### PR DESCRIPTION
Adds comprehensive pre-commit hooks configuration copied from requests-mock-flask. Includes linting, type checking, formatting, and documentation validation for Python code, shell scripts, YAML, and Sphinx documentation. Module name updated to sphinx_literalizer for pyright type verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds developer tooling configuration and does not change runtime code paths; primary impact is potential new local/pre-push failures due to stricter checks.
> 
> **Overview**
> Introduces a new `.pre-commit-config.yaml` that enables **pre-commit and pre-push quality gates** across the repo (basic file hygiene checks plus Python/shell/docs linting, formatting, and multiple type-checkers), largely executed via `uv run` with pinned `uv==0.9.5`.
> 
> Configures pre-commit CI to *skip* these heavier hooks, while still running them locally at the appropriate stages (`pre-commit`, `pre-push`, and some `manual`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40c2a567c85e8485ea296fb239149d2488f7c0db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->