### PR TITLE
Add mypy with strict-kwargs plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,20 @@ classifiers = [
 ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-literalizer"
 
+[project.optional-dependencies]
+dev = [
+    "mypy[faster-cache]==1.19.1",
+    "mypy-strict-kwargs==2026.1.12",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.mypy]
+strict = true
+files = [ "." ]
+exclude = [ "build" ]
+plugins = [
+    "mypy_strict_kwargs",
+]
+follow_untyped_imports = true


### PR DESCRIPTION
Configure mypy with strict mode and the mypy-strict-kwargs plugin to enforce type safety on function arguments. Matches the configuration from the requests-mock-flask project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds development-only type-checking dependencies and `mypy` configuration, without changing runtime code paths.
> 
> **Overview**
> Adds a `dev` optional dependency group in `pyproject.toml` for `mypy` (with faster cache) and the `mypy-strict-kwargs` plugin.
> 
> Configures `mypy` in strict mode, enables the `mypy_strict_kwargs` plugin, and sets basic project-wide targets/exclusions (`files = ["."]`, `exclude = ["build"]`, `follow_untyped_imports = true`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f918ad88c68d8110d9be660de686d70cf2e8fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->