### PR TITLE
Fix pre-commit hook configuration issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,7 +130,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies: [uv==0.9.5]
@@ -161,6 +161,7 @@ repos:
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
         language: python
         types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
 
       - id: check-manifest
         name: check-manifest
@@ -186,6 +187,7 @@ repos:
           --command="pyright"
         language: python
         types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
 
       - id: pyright-verifytypes
         name: pyright-verifytypes
@@ -246,7 +248,7 @@ repos:
         entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
           --command="vulture"
         language: python
-        types_or: [python]
+        types_or: [markdown, rst]
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]
@@ -283,6 +285,7 @@ repos:
         language: python
         stages: [manual]
         types_or: [markdown, rst]
+        additional_dependencies: [uv==0.9.5]
 
       - id: ruff-check-fix
         name: Ruff check fix
@@ -380,7 +383,7 @@ repos:
         additional_dependencies: [uv==0.9.5]
 
       - id: yamlfix
-        name: pyproject-fmt
+        name: yamlfix
         entry: uv run --extra=dev yamlfix
         language: python
         types_or: [yaml]


### PR DESCRIPTION
Addresses four bugbot-identified issues in the pre-commit configuration:

- Fixed yamlfix hook name (was incorrectly set to 'pyproject-fmt')
- Fixed vulture-docs hook to target markdown/rst files instead of python files
- Added missing uv run prefix to shfmt entry to use project-managed binary
- Added missing additional_dependencies entries for mypy-docs, pyright-docs, and pylint-docs hooks

These fixes ensure all hooks have correct file type targeting and proper dependency configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only changes to developer tooling; main risk is minor disruption if a hook command or file selector is still misconfigured.
> 
> **Overview**
> Fixes local `pre-commit` hook configuration issues so the right tools run in the right environments.
> 
> Updates `shfmt` to execute via `uv run`, adds missing `uv==0.9.5` `additional_dependencies` to `mypy-docs`, `pyright-docs`, and `pylint-docs`, corrects `vulture-docs` to target `markdown`/`rst` instead of `python`, and renames the `yamlfix` hook display name from an incorrect `pyproject-fmt` label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb3c0a821929beeea1cff983c800e31164076b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->