### PR TITLE
Fix PyPI metadata validation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Requires Python |minimum-python-version|\+.
 Usage
 -----
 
-Add to your Sphinx :file:`conf.py`:
+Add to your Sphinx ``conf.py``:
 
 .. code-block:: python
 


### PR DESCRIPTION
Replace Sphinx-specific :file: role with standard RST inline code literal. The :file: role is not supported by PyPI's docutils renderer and causes metadata validation to fail during release with 'long_description has syntax errors in markup'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adjusts README markup; no runtime code or behavior changes.
> 
> **Overview**
> Updates `README.rst` to replace the Sphinx-specific `:file:` role with a plain inline code literal (``conf.py``), improving compatibility with PyPI’s docutils renderer and avoiding long_description markup validation failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97cb92b847c74d0a11eab332694f53d0a1f06a54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->