### PR TITLE
Use literalize_yaml for all data files

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -4,7 +4,6 @@ Provides the ``literalizer`` directive, which reads a JSON file and
 renders it as a native language literal block.
 """
 
-import json
 from pathlib import Path
 from typing import ClassVar
 
@@ -21,7 +20,7 @@ from literalizer import (
     RUBY,
     TYPESCRIPT,
     Language,
-    literalize,
+    literalize_yaml,
 )
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
@@ -62,15 +61,13 @@ class LiteralizerDirective(SphinxDirective):
     }
 
     def run(self) -> list[nodes.Node]:
-        """Read the JSON file and produce a literal block."""
+        """Read the data file and produce a literal block."""
         env = self.state.document.settings.env
         rel_path = self.arguments[0]
         source_dir = Path(env.srcdir)
-        json_path = (source_dir / rel_path).resolve()
+        data_path = (source_dir / rel_path).resolve()
 
-        env.note_dependency(str(json_path))
-
-        data = json.loads(json_path.read_text(encoding="utf-8"))
+        env.note_dependency(str(data_path))
 
         language_name: str = self.options["language"]
         language_spec = _LANGUAGES[language_name]
@@ -80,8 +77,10 @@ class LiteralizerDirective(SphinxDirective):
         prefix = prefix_char * prefix_count
         wrap: bool = "wrap" in self.options
 
-        text = literalize(
-            data=data,
+        # YAML is a superset of JSON, so literalize_yaml handles both
+        # .yaml/.yml files and .json files without any format detection.
+        text = literalize_yaml(
+            yaml_string=data_path.read_text(encoding="utf-8"),
             language=language_spec,
             prefix=prefix,
             wrap=wrap,
@@ -93,7 +92,7 @@ class LiteralizerDirective(SphinxDirective):
         # Sphinx's built-in LiteralInclude directive, which also stores an
         # absolute path so that downstream code can rely on it without having
         # to resolve relative→absolute itself.
-        node = nodes.literal_block(text, text, source=str(json_path))
+        node = nodes.literal_block(text, text, source=str(data_path))
         node["language"] = language_name
         self.add_name(node=node)
         return [node]

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -330,6 +330,67 @@ def test_wrap_adds_brackets(
     assert content_html == expected_html
 
 
+def test_yaml_file_python(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A YAML sequence renders the same as an equivalent Python code-block."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(
+        dedent("""\
+            - true
+            - false
+            - true
+        """)
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: python
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           True,
+           False,
+           True,
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
 def test_no_wrap_by_default(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
YAML is a superset of JSON, so using literalize_yaml handles both .yaml/.yml and .json files without any format detection logic. This removes the manual json.loads() call and simplifies the code. Adds a test case for YAML file support with dedent for cleaner formatting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching from `json.loads()` to `literalize_yaml()` changes the parsing/serialization path for all existing `.json` inputs and may subtly alter output or accepted syntax. Scope is small and covered by integration tests, but it affects the directive’s core rendering behavior.
> 
> **Overview**
> Updates the `literalizer` Sphinx directive to treat its input as a *data file* rather than JSON-only by removing `json.loads()` and routing all content through `literalize_yaml()` (YAML superset of JSON), enabling `.yaml/.yml` and `.json` with no format detection.
> 
> Adds an integration test (`test_yaml_file_python`) that verifies a YAML sequence renders identically to an equivalent `.. code-block:: python` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd5eb3aba9fb387205d5ea1744c3d7097294413a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->