### PR TITLE
Bump literalizer to 2026.3.15.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "literalizer>=2026.3.15",
+    "literalizer>=2026.3.15.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -350,15 +350,15 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.3.15"
+version = "2026.3.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/af/44ea1f28e1479140d7f773f7780f05de6e56ec2e923a4fb0259281b34cda/literalizer-2026.3.15.tar.gz", hash = "sha256:73427934f29fed0561337e5038c1fcba6238d35e21b4b1c001df6b19e1beada3", size = 32802, upload-time = "2026-03-15T14:22:06.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/55/3f0b238f23f8d128b8f63ae826347fec368d274afa19379e2e8f338e54d9/literalizer-2026.3.15.1.tar.gz", hash = "sha256:ae0e2750900f147973bad3d4d42ca90b95226442ce0b71e95b0a6dc3cdd96614", size = 37484, upload-time = "2026-03-15T15:09:10.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/89/b486c02e4c97e0906a441d4aa220effb413912db3c6826151820cf9e6b78/literalizer-2026.3.15-py3-none-any.whl", hash = "sha256:51e3794714d42851e0efde6df4942cdea249805b2cd5bee3e5f265774dc1e6c2", size = 9474, upload-time = "2026-03-15T14:22:05.616Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/2d/0253e7b0cd90b2124f9c464db3124a13428b9dc809572a34c5aa5a65c38e/literalizer-2026.3.15.1-py3-none-any.whl", hash = "sha256:8c5a8a4acdfd4e064e3345639b5ac035889e77ddd2d4b2e0a610198b1492c4ac", size = 12100, upload-time = "2026-03-15T15:09:08.84Z" },
 ]
 
 [[package]]
@@ -873,7 +873,7 @@ requires-dist = [
     { name = "beartype", marker = "extra == 'dev'", specifier = "==0.22.9" },
     { name = "check-wheel-contents", marker = "extra == 'release'", specifier = "==0.6.3" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
-    { name = "literalizer", specifier = ">=2026.3.15" },
+    { name = "literalizer", specifier = ">=2026.3.15.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.5" },
     { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.18.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },


### PR DESCRIPTION
Update literalizer dependency to the latest patch version 2026.3.15.1, including updates to pyproject.toml and uv.lock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch-level dependency bump; changes are limited to dependency constraints and lockfile resolution.
> 
> **Overview**
> Bumps the `literalizer` dependency from `2026.3.15` to `2026.3.15.1` in `pyproject.toml`.
> 
> Updates `uv.lock` to pin `literalizer==2026.3.15.1` (including refreshed sdist/wheel URLs/hashes) and aligns the generated `requires-dist` metadata accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b264f1461e4408d9db16e8c2a0fa0164398e166c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->