### PR TITLE
Support Swift, PHP, and variable-name option

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -19,8 +19,10 @@ from literalizer import (
     JAVA,
     JAVASCRIPT,
     KOTLIN,
+    PHP,
     PYTHON,
     RUBY,
+    SWIFT,
     TYPESCRIPT,
     LanguageSpec,
     format_date_cpp,
@@ -30,6 +32,7 @@ from literalizer import (
     format_date_java,
     format_date_js,
     format_date_kotlin,
+    format_date_php,
     format_date_python,
     format_date_ruby,
     format_datetime_cpp,
@@ -41,6 +44,7 @@ from literalizer import (
     format_datetime_java_zoned,
     format_datetime_js,
     format_datetime_kotlin,
+    format_datetime_php,
     format_datetime_python,
     format_datetime_ruby,
     literalize_yaml,
@@ -56,8 +60,10 @@ _LANGUAGES: dict[str, LanguageSpec] = {
     "java": JAVA,
     "javascript": JAVASCRIPT,
     "kotlin": KOTLIN,
+    "php": PHP,
     "python": PYTHON,
     "ruby": RUBY,
+    "swift": SWIFT,
     "typescript": TYPESCRIPT,
 }
 
@@ -113,6 +119,10 @@ _DATE_FORMATS: dict[str, _DateFormat] = {
         format_date=format_date_cpp,
         format_datetime=format_datetime_cpp,
     ),
+    "php": _DateFormat(
+        format_date=format_date_php,
+        format_datetime=format_datetime_php,
+    ),
 }
 
 
@@ -136,6 +146,7 @@ class LiteralizerDirective(SphinxDirective):
         "prefix-char": lambda x: directives.choice(x, ("spaces", "tabs")),
         "wrap": directives.flag,
         "date-format": lambda x: directives.choice(x, tuple(_DATE_FORMATS)),
+        "variable-name": directives.unchanged,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -162,6 +173,7 @@ class LiteralizerDirective(SphinxDirective):
         prefix_char = "\t" if prefix_char_name == "tabs" else " "
         prefix = prefix_char * prefix_count
         wrap: bool = "wrap" in self.options
+        variable_name: str | None = self.options.get("variable-name")
 
         # YAML is a superset of JSON, so literalize_yaml handles both
         # .yaml/.yml files and .json files without any format detection.
@@ -170,6 +182,7 @@ class LiteralizerDirective(SphinxDirective):
             language=language_spec,
             prefix=prefix,
             wrap=wrap,
+            variable_name=variable_name,
         )
 
         # First positional arg sets rawsource; Sphinx requires

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -564,6 +564,172 @@ def test_date_format_java_instant(
     assert content_html == expected_html
 
 
+def test_swift_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the swift language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: swift
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: swift
+
+           1,
+           2,
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_php_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the php language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: php
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: php
+
+           1,
+           2,
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_variable_name_python(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :variable-name: option wraps output in a variable declaration."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :wrap:
+           :variable-name: my_list
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           my_list = (
+               1,
+               2,
+           )
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
 def test_no_wrap_by_default(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Add support for Swift and PHP languages from literalizer 2026.3.16. Implement the new optional variable-name parameter to generate native variable declarations (e.g., `x = [...]` in Python, `const x = [...]` in JS). Also add PHP date formatting options.

All 14 tests pass, including three new tests for Swift language, PHP language, and variable-name functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes directive output generation by adding a new `:variable-name:` option and expanding language/date-format mappings, which could alter rendered code blocks for some configurations.
> 
> **Overview**
> Adds **Swift** and **PHP** as supported `:language:` values for the `.. literalizer::` directive, including PHP-specific date/datetime formatting via the underlying `literalizer` library.
> 
> Introduces an optional `:variable-name:` directive option that forwards `variable_name` to `literalize_yaml` to wrap generated literals in a native variable declaration when supported.
> 
> Extends integration coverage with new tests validating Swift/PHP rendering and `:variable-name:` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6d0875b168d24eaf20f9e757d3656ee408ecaed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->