### PR TITLE
Use functools.partial instead of lambdas for directives.choice

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -6,6 +6,7 @@ renders it as a native language literal block.
 
 import dataclasses
 import datetime
+import functools
 from collections.abc import Callable
 from pathlib import Path
 from typing import ClassVar
@@ -143,9 +144,15 @@ class LiteralizerDirective(SphinxDirective):
     option_spec: ClassVar[dict[str, object]] = {
         "language": directives.unchanged_required,
         "prefix": directives.nonnegative_int,
-        "prefix-char": lambda x: directives.choice(x, ("spaces", "tabs")),
+        "prefix-char": functools.partial(
+            directives.choice,
+            values=("spaces", "tabs"),
+        ),
         "wrap": directives.flag,
-        "date-format": lambda x: directives.choice(x, tuple(_DATE_FORMATS)),
+        "date-format": functools.partial(
+            directives.choice,
+            values=tuple(_DATE_FORMATS),
+        ),
         "variable-name": directives.unchanged,
     }
 


### PR DESCRIPTION
Replaces the lambda wrappers around `directives.choice` in `option_spec` with `functools.partial`, as suggested in #18.

Closes #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to directive option parsing; behavior should remain the same aside from how the validators are constructed.
> 
> **Overview**
> Refactors `LiteralizerDirective.option_spec` to replace inline lambda wrappers around `directives.choice` with `functools.partial` for `prefix-char` and `date-format`, and adds the required `functools` import. No functional behavior changes are intended; this just standardizes how the choice validators are defined.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f9720ad3786c686211c3a4b1d7a717a9920d1ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->