### PR TITLE
Add mypy-strict-kwargs plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ optional-dependencies.dev = [
     "furo==2025.12.19",
     "interrogate==1.7.0",
     "mypy==1.19.1",
+    "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.6",
     "pydocstringformatter==0.7.5",
     "pyproject-fmt==2.19.0",
@@ -164,6 +165,7 @@ files = [ "." ]
 exclude = [
     "build",
 ]
+plugins = [ "mypy_strict_kwargs" ]
 follow_untyped_imports = true
 
 [tool.pyrefly]

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -146,9 +146,15 @@ class LiteralizerDirective(SphinxDirective):
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
         "language": directives.unchanged_required,
         "prefix": directives.nonnegative_int,
-        "prefix-char": lambda x: directives.choice(x, ("spaces", "tabs")),
+        "prefix-char": lambda x: directives.choice(
+            argument=x,
+            values=("spaces", "tabs"),
+        ),
         "wrap": directives.flag,
-        "date-format": lambda x: directives.choice(x, tuple(_DATE_FORMATS)),
+        "date-format": lambda x: directives.choice(
+            argument=x,
+            values=tuple(_DATE_FORMATS),
+        ),
         "variable-name": directives.unchanged,
     }
 
@@ -159,7 +165,7 @@ class LiteralizerDirective(SphinxDirective):
         source_dir = Path(env.srcdir)
         data_path = (source_dir / rel_path).resolve()
 
-        env.note_dependency(str(data_path))
+        env.note_dependency(str(object=data_path))
 
         language_name: str = self.options["language"]
         language_spec: LanguageSpec = _LANGUAGES[language_name]
@@ -194,7 +200,11 @@ class LiteralizerDirective(SphinxDirective):
         # Sphinx's built-in LiteralInclude directive, which also stores an
         # absolute path so that downstream code can rely on it without having
         # to resolve relative→absolute itself.
-        node = nodes.literal_block(text, text, source=str(data_path))
+        node = nodes.literal_block(
+            text,
+            text,
+            source=str(object=data_path),
+        )
         node["language"] = language_name
         self.add_name(node=node)
         return [node]
@@ -202,7 +212,7 @@ class LiteralizerDirective(SphinxDirective):
 
 def setup(app: Sphinx) -> ExtensionMetadata:
     """Register the extension with Sphinx."""
-    app.add_directive("literalizer", LiteralizerDirective)
+    app.add_directive(name="literalizer", cls=LiteralizerDirective)
     return {
         "version": "0.1.0",
         "parallel_read_safe": True,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -24,9 +24,9 @@ def test_source_attribute_is_absolute(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1]))
     (source_directory / "index.rst").write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -44,8 +44,8 @@ def test_source_attribute_is_absolute(
     app.build()
     assert app.statuscode == 0
 
-    doctree = app.env.get_doctree("index")
-    literal_blocks = list(doctree.findall(nodes.literal_block))
+    doctree = app.env.get_doctree(docname="index")
+    literal_blocks = list(doctree.findall(condition=nodes.literal_block))
     (literal_block,) = literal_blocks
     source = literal_block["source"]
     assert Path(source).is_absolute()
@@ -64,11 +64,11 @@ def test_boolean_array_python(
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
     (source_directory / "data.json").write_text(
-        json.dumps([True, False, True]),
+        data=json.dumps(obj=[True, False, True]),
     )
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -89,7 +89,7 @@ def test_boolean_array_python(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -123,11 +123,11 @@ def test_array_of_arrays_typescript(
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
     (source_directory / "data.json").write_text(
-        json.dumps([["a", 1.0]]),
+        data=json.dumps(obj=[["a", 1.0]]),
     )
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -148,7 +148,7 @@ def test_array_of_arrays_typescript(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -177,10 +177,10 @@ def test_prefix_spaces(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1]))
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -201,9 +201,9 @@ def test_prefix_spaces(
     content_html = (app.outdir / "index.html").read_text()
     app.cleanup()
 
-    (source_directory / "expected.py").write_text("    1,\n")
+    (source_directory / "expected.py").write_text(data="    1,\n")
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -231,10 +231,10 @@ def test_prefix_tabs(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1]))
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -256,9 +256,9 @@ def test_prefix_tabs(
     content_html = (app.outdir / "index.html").read_text()
     app.cleanup()
 
-    (source_directory / "expected.go").write_text("\t\t1,\n")
+    (source_directory / "expected.go").write_text(data="\t\t1,\n")
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -288,10 +288,10 @@ def test_wrap_adds_brackets(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -313,7 +313,7 @@ def test_wrap_adds_brackets(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -346,15 +346,17 @@ def test_yaml_file_python(
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
     (source_directory / "data.yaml").write_text(
-        dedent("""\
+        data=dedent(
+            text="""\
             - true
             - false
             - true
-        """)
+        """
+        )
     )
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -375,7 +377,7 @@ def test_yaml_file_python(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -407,13 +409,15 @@ def test_date_format_python(
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
     (source_directory / "data.yaml").write_text(
-        dedent("""\
+        data=dedent(
+            text="""\
             - 2024-01-15
-        """)
+        """
+        )
     )
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -435,7 +439,7 @@ def test_date_format_python(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -467,13 +471,15 @@ def test_date_format_iso_default(
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
     (source_directory / "data.yaml").write_text(
-        dedent("""\
+        data=dedent(
+            text="""\
             - 2024-01-15
-        """)
+        """
+        )
     )
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -494,7 +500,7 @@ def test_date_format_iso_default(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -524,13 +530,15 @@ def test_date_format_java_instant(
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
     (source_directory / "data.yaml").write_text(
-        dedent("""\
+        data=dedent(
+            text="""\
             - 2024-01-15
-        """)
+        """
+        )
     )
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -552,7 +560,7 @@ def test_date_format_java_instant(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -581,10 +589,10 @@ def test_swift_language(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -605,7 +613,7 @@ def test_swift_language(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -635,10 +643,10 @@ def test_php_language(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -659,7 +667,7 @@ def test_php_language(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -691,10 +699,10 @@ def test_variable_name_python(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -717,7 +725,7 @@ def test_variable_name_python(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -749,10 +757,10 @@ def test_no_wrap_by_default(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "data.json").write_text(json.dumps([1, 2]))
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
     source_file = source_directory / "index.rst"
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====
@@ -773,7 +781,7 @@ def test_no_wrap_by_default(
     app.cleanup()
 
     source_file.write_text(
-        dedent(
+        data=dedent(
             text="""\
         Test
         ====

--- a/uv.lock
+++ b/uv.lock
@@ -773,6 +773,19 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy-strict-kwargs"
+version = "2026.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/77/869682567b0953f3f9ea6b44639a2a520e0976679a93e4fd4a91840ac43a/mypy_strict_kwargs-2026.1.12.tar.gz", hash = "sha256:abc688be88661e14f19626e00686f42cc6ce3a959e9cd86e0523dee2b5509cac", size = 18756, upload-time = "2026-01-12T06:12:03.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/93/918273959da1d3364478742f45e5579489acd100a6184061f57d64b37be7/mypy_strict_kwargs-2026.1.12-py2.py3-none-any.whl", hash = "sha256:54529ed7d9912be26f4aedb200e5c4d577fb592398c4038b551a3a07ea83361d", size = 7095, upload-time = "2026-01-12T06:12:01.884Z" },
+]
+
+[[package]]
 name = "myst-parser"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1485,6 +1498,7 @@ dev = [
     { name = "furo" },
     { name = "interrogate" },
     { name = "mypy" },
+    { name = "mypy-strict-kwargs" },
     { name = "prek" },
     { name = "pydocstringformatter" },
     { name = "pyproject-fmt" },
@@ -1526,6 +1540,7 @@ requires-dist = [
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "literalizer", specifier = ">=2026.3.16.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
+    { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.6" },
     { name = "pydocstringformatter", marker = "extra == 'dev'", specifier = "==0.7.5" },
     { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.19.0" },
@@ -1698,6 +1713,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/32/4689172cc19f55b8390dca4a0384d8e177f623621156f0c9b3963c720eab/toml_fmt_common-1.3.1.tar.gz", hash = "sha256:da19c5a485e9f3f1f154a54e05c7b4aadd6147478286d7547e91ba54e4f755fc", size = 7433, upload-time = "2026-03-02T04:23:20.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/b5/c58d6ac40438898a4a19d958e67bf5f55a22afbc3cddb1cb23eda1d18a55/toml_fmt_common-1.3.1-py3-none-any.whl", hash = "sha256:5468567afe9702679682ab3fa973c79279a9f1420767e5c54481cd211df752fc", size = 5472, upload-time = "2026-03-02T04:23:18.925Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add mypy-strict-kwargs plugin to enforce keyword-only arguments in function calls, improving code clarity and reducing bugs. Updates mypy configuration to use the plugin and fixes all violations by converting positional arguments to keyword arguments throughout the codebase.

Changes include:
- Added mypy-strict-kwargs==2026.1.12 to dev dependencies
- Enabled mypy_strict_kwargs plugin in [tool.mypy]
- Fixed all function calls to use keyword arguments where required (directives.choice, Path.write_text, json.dumps, dedent, get_doctree, add_directive, findall)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a typing/tooling change; runtime behavior should be unchanged aside from switching several calls to keyword arguments, with low risk of subtle signature mismatches if upstream APIs differ.
> 
> **Overview**
> Adds the `mypy-strict-kwargs` mypy plugin (plus lockfile updates) and enables it in `pyproject.toml` to enforce keyword-only arguments.
> 
> Updates the Sphinx extension and integration tests to satisfy the new rule by converting affected calls to explicit keyword arguments (e.g., `directives.choice`, `env.note_dependency`, `nodes.literal_block`, `app.add_directive`, and various test helpers like `write_text`, `json.dumps`, `dedent`, `get_doctree`, `findall`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bc82ea4c9ad4cf51b832561590d31647bc2de17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->