### PR TITLE
Bump literalizer to 2026.3.17.1 and add new features

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,8 +41,9 @@ Directive options
 
 ``:language:`` (required)
    Target language name (Pygments language name).
-   Supported values: ``python``, ``typescript``, ``javascript``, ``go``,
-   ``cpp``, ``csharp``, ``ruby``, ``java``, ``kotlin``.
+   Supported values: ``cpp``, ``csharp``, ``dart``, ``go``, ``java``,
+   ``javascript``, ``julia``, ``kotlin``, ``php``, ``python``, ``ruby``,
+   ``swift``, ``typescript``.
 
 ``:prefix:`` (optional)
    Number of whitespace characters to prepend to each output line.
@@ -83,6 +84,20 @@ Directive options
       ``LocalDate.of(...)`` / ``LocalDateTime.of(...)``.
    ``cpp``
       ``std::chrono`` types.
+   ``dart``
+      ``DateTime.parse(...)`` for dates and datetimes.
+   ``julia``
+      ``Date(...)`` / ``DateTime(...)`` constructors.
+
+``:variable-name:`` (optional)
+   Wrap the output in a variable declaration or assignment using the given
+   name.  Use with ``:wrap:`` to include the collection delimiters.
+
+``:existing-variable:`` (optional flag)
+   When combined with ``:variable-name:``, produce an assignment to an
+   existing variable (e.g. ``x = ...``) instead of a new variable
+   declaration (e.g. ``final x = ...`` in Dart).  Has no effect without
+   ``:variable-name:``.
 
 Example
 ~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "docutils",
-    "literalizer>=2026.3.16.2",
+    "literalizer>=2026.3.17.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -16,22 +16,26 @@ from literalizer import LanguageSpec, literalize_yaml
 from literalizer.formatters import (
     format_date_cpp,
     format_date_csharp,
+    format_date_dart,
     format_date_go,
     format_date_iso,
     format_date_java,
     format_date_js,
+    format_date_julia,
     format_date_kotlin,
     format_date_php,
     format_date_python,
     format_date_ruby,
     format_datetime_cpp,
     format_datetime_csharp,
+    format_datetime_dart,
     format_datetime_epoch,
     format_datetime_go,
     format_datetime_iso,
     format_datetime_java_instant,
     format_datetime_java_zoned,
     format_datetime_js,
+    format_datetime_julia,
     format_datetime_kotlin,
     format_datetime_php,
     format_datetime_python,
@@ -40,9 +44,11 @@ from literalizer.formatters import (
 from literalizer.languages import (
     CPP,
     CSHARP,
+    DART,
     GO,
     JAVA,
     JAVASCRIPT,
+    JULIA,
     KOTLIN,
     PHP,
     PYTHON,
@@ -57,9 +63,11 @@ from sphinx.util.typing import ExtensionMetadata
 _LANGUAGES: dict[str, LanguageSpec] = {
     "cpp": CPP,
     "csharp": CSHARP,
+    "dart": DART,
     "go": GO,
     "java": JAVA,
     "javascript": JAVASCRIPT,
+    "julia": JULIA,
     "kotlin": KOTLIN,
     "php": PHP,
     "python": PYTHON,
@@ -78,9 +86,17 @@ class _DateFormat:
 
 
 _DATE_FORMATS: dict[str, _DateFormat] = {
+    "dart": _DateFormat(
+        format_date=format_date_dart,
+        format_datetime=format_datetime_dart,
+    ),
     "iso": _DateFormat(
         format_date=format_date_iso,
         format_datetime=format_datetime_iso,
+    ),
+    "julia": _DateFormat(
+        format_date=format_date_julia,
+        format_datetime=format_datetime_julia,
     ),
     "python": _DateFormat(
         format_date=format_date_python,
@@ -139,6 +155,8 @@ class LiteralizerDirective(SphinxDirective):
            :prefix: 8
            :prefix-char: spaces
            :wrap:
+           :variable-name: my_var
+           :existing-variable:
     """
 
     required_arguments = 1
@@ -156,6 +174,7 @@ class LiteralizerDirective(SphinxDirective):
             values=tuple(_DATE_FORMATS),
         ),
         "variable-name": directives.unchanged,
+        "existing-variable": directives.flag,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -183,6 +202,7 @@ class LiteralizerDirective(SphinxDirective):
         prefix = prefix_char * prefix_count
         wrap: bool = "wrap" in self.options
         variable_name: str | None = self.options.get("variable-name")
+        existing_variable: bool = "existing-variable" in self.options
 
         # YAML is a superset of JSON, so literalize_yaml handles both
         # .yaml/.yml files and .json files without any format detection.
@@ -192,6 +212,7 @@ class LiteralizerDirective(SphinxDirective):
             prefix=prefix,
             wrap=wrap,
             variable_name=variable_name,
+            new_variable=not existing_variable,
         )
 
         # First positional arg sets rawsource; Sphinx requires

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -748,6 +748,177 @@ def test_variable_name_python(
     assert content_html == expected_html
 
 
+def test_dart_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the dart language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: dart
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: dart
+
+           1,
+           2,
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_julia_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the julia language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: julia
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: julia
+
+           1,
+           2,
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_existing_variable_dart(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :existing-variable: flag produces a variable assignment
+    instead of a declaration.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: dart
+           :wrap:
+           :variable-name: myList
+           :existing-variable:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: dart
+           :wrap:
+           :variable-name: myList
+    """
+        )
+    )
+    new_variable_app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    new_variable_app.build()
+    assert new_variable_app.statuscode == 0
+    new_variable_html = (new_variable_app.outdir / "index.html").read_text()
+    new_variable_app.cleanup()
+
+    # Assignment (existing-variable) differs from declaration (new variable)
+    assert content_html != new_variable_html
+
+
 def test_no_wrap_by_default(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -595,15 +595,15 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.3.16.2"
+version = "2026.3.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/59/35501a85e13e3da0d7befa35dd6bfe50f657ffb156ea108925c9db40039a/literalizer-2026.3.16.2.tar.gz", hash = "sha256:e10fe8a1672cb955d2a29c7b64af992e8a4b5f8543508bf22721982727afd062", size = 65321, upload-time = "2026-03-16T13:34:08.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/2b/8a7763ccfb280614f4db3e645032652b78cbaa33f9d6d055c3a6c39604c0/literalizer-2026.3.17.1.tar.gz", hash = "sha256:db4b4380cc6cf5657988446741f3dfd02d0f0e1bca6e32d1091c16c822296734", size = 70387, upload-time = "2026-03-17T12:01:49.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/69/e9886b53a35d4840fa5ffc2d47fad5bd01dba1ffcb0ad0ef31dfebb3a4ad/literalizer-2026.3.16.2-py3-none-any.whl", hash = "sha256:691f1a380e1ac6ef0098fba9f312b1865ff487a0f0ac88213144df7b5969ee18", size = 17754, upload-time = "2026-03-16T13:34:06.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cb/4c54b6b9627679127ffe2aea6b8ef7a977d8f2a2dd5098a3e4cfbfd042be/literalizer-2026.3.17.1-py3-none-any.whl", hash = "sha256:44e36ab7734af5d72fa6601903728098fdf49907faed9c7f62f2fb7497403b75", size = 18626, upload-time = "2026-03-17T12:01:48.457Z" },
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = ">=2026.3.16.2" },
+    { name = "literalizer", specifier = ">=2026.3.17.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.6" },


### PR DESCRIPTION
## Summary

- Bumped literalizer dependency to 2026.3.17.1
- Added support for Dart and Julia languages with language-specific date formatting
- Added `:existing-variable:` directive option to control variable declaration vs assignment

## Test Plan

All 17 tests pass, including 3 new tests for Dart, Julia, and the existing-variable flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the core directive output behavior by bumping `literalizer` and adding a new `:existing-variable:` path that changes how variable wrappers are emitted; could affect rendered docs for users relying on previous formatting.
> 
> **Overview**
> Bumps the `literalizer` dependency to `2026.3.17.1` and wires through new language support for **Dart** and **Julia**, including language-specific date/datetime formatting options.
> 
> Extends the `literalizer` directive with `:existing-variable:` to control whether `:variable-name:` generates a new declaration vs assigning to an existing variable (via `new_variable=...`). Documentation and integration tests are updated to cover the new languages and flag behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32e3773473fb9ba52581e30110ae898223235014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->