### PR TITLE
Bump literalizer to 2026.3.17.2 and add support for Clojure, Scala, R

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+2026.03.17.2
+------------
+
+- Bumped ``literalizer`` to ``2026.3.17.2``.
+- Added support for Clojure, Scala, and R languages.
+- Added ``r`` date format (``as.Date(...)`` / ``as.POSIXct(...)``).
+
 2026.03.17
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,9 +41,9 @@ Directive options
 
 ``:language:`` (required)
    Target language name (Pygments language name).
-   Supported values: ``cpp``, ``csharp``, ``dart``, ``go``, ``java``,
-   ``javascript``, ``julia``, ``kotlin``, ``php``, ``python``, ``ruby``,
-   ``swift``, ``typescript``.
+   Supported values: ``clojure``, ``cpp``, ``csharp``, ``dart``, ``go``,
+   ``java``, ``javascript``, ``julia``, ``kotlin``, ``php``, ``python``,
+   ``r``, ``ruby``, ``scala``, ``swift``, ``typescript``.
 
 ``:prefix:`` (optional)
    Number of whitespace characters to prepend to each output line.
@@ -88,6 +88,8 @@ Directive options
       ``DateTime.parse(...)`` for dates and datetimes.
    ``julia``
       ``Date(...)`` / ``DateTime(...)`` constructors.
+   ``r``
+      ``as.Date(...)`` / ``as.POSIXct(...)`` calls.
 
 ``:variable-name:`` (optional)
    Wrap the output in a variable declaration or assignment using the given

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "docutils",
-    "literalizer>=2026.3.17.1",
+    "literalizer>=2026.3.17.2",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -25,6 +25,7 @@ from literalizer.formatters import (
     format_date_kotlin,
     format_date_php,
     format_date_python,
+    format_date_r,
     format_date_ruby,
     format_datetime_cpp,
     format_datetime_csharp,
@@ -39,9 +40,11 @@ from literalizer.formatters import (
     format_datetime_kotlin,
     format_datetime_php,
     format_datetime_python,
+    format_datetime_r,
     format_datetime_ruby,
 )
 from literalizer.languages import (
+    CLOJURE,
     CPP,
     CSHARP,
     DART,
@@ -53,14 +56,17 @@ from literalizer.languages import (
     PHP,
     PYTHON,
     RUBY,
+    SCALA,
     SWIFT,
     TYPESCRIPT,
+    R,
 )
 from sphinx.application import Sphinx
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.typing import ExtensionMetadata
 
 _LANGUAGES: dict[str, LanguageSpec] = {
+    "clojure": CLOJURE,
     "cpp": CPP,
     "csharp": CSHARP,
     "dart": DART,
@@ -71,7 +77,9 @@ _LANGUAGES: dict[str, LanguageSpec] = {
     "kotlin": KOTLIN,
     "php": PHP,
     "python": PYTHON,
+    "r": R,
     "ruby": RUBY,
+    "scala": SCALA,
     "swift": SWIFT,
     "typescript": TYPESCRIPT,
 }
@@ -141,6 +149,10 @@ _DATE_FORMATS: dict[str, _DateFormat] = {
     "php": _DateFormat(
         format_date=format_date_php,
         format_datetime=format_datetime_php,
+    ),
+    "r": _DateFormat(
+        format_date=format_date_r,
+        format_datetime=format_datetime_r,
     ),
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -595,15 +595,15 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.3.17.1"
+version = "2026.3.17.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/2b/8a7763ccfb280614f4db3e645032652b78cbaa33f9d6d055c3a6c39604c0/literalizer-2026.3.17.1.tar.gz", hash = "sha256:db4b4380cc6cf5657988446741f3dfd02d0f0e1bca6e32d1091c16c822296734", size = 70387, upload-time = "2026-03-17T12:01:49.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/be/b9941a71cb8832b56020a66f520de2760db9bf6a043834a2c9e50d87d03a/literalizer-2026.3.17.2.tar.gz", hash = "sha256:ea858e5ae3109fdcc377baba20f3815ccba4d940a0ef6569b28f6cadcc94516a", size = 92577, upload-time = "2026-03-17T13:21:58.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/cb/4c54b6b9627679127ffe2aea6b8ef7a977d8f2a2dd5098a3e4cfbfd042be/literalizer-2026.3.17.1-py3-none-any.whl", hash = "sha256:44e36ab7734af5d72fa6601903728098fdf49907faed9c7f62f2fb7497403b75", size = 18626, upload-time = "2026-03-17T12:01:48.457Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fd/f2b1a36eb3111207b1e4b3a9ab9ce2d03d3e23e275702d3387b45935dc37/literalizer-2026.3.17.2-py3-none-any.whl", hash = "sha256:69e9aafba6b9a815b3f5640c1d52de4aaa341aa0f4159c634bb796e3f97a2978", size = 19191, upload-time = "2026-03-17T13:21:57.142Z" },
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = ">=2026.3.17.1" },
+    { name = "literalizer", specifier = ">=2026.3.17.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.6" },


### PR DESCRIPTION
Adds support for three new languages (Clojure, Scala, R) from literalizer 2026.3.17.2.

Includes date formatters for R (`as.Date(...)`/`as.POSIXct(...)`) and documentation updates for all new supported languages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly a dependency bump plus wiring new language specs and an R date/datetime formatter option; potential issues are limited to literal rendering for the newly supported languages and the updated `literalizer` version.
> 
> **Overview**
> Updates the `literalizer` dependency to `2026.3.17.2` and refreshes the lockfile accordingly.
> 
> Extends the `literalizer` Sphinx directive to recognize **Clojure, Scala, and R** as `:language:` targets, and adds an `r` `:date-format:` option that formats dates via `as.Date(...)` and datetimes via `as.POSIXct(...)`.
> 
> Documentation and changelog are updated to reflect the new supported languages and R date-format behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e961be6813bf62fdefbb70f9d2556bddd79c779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->