### PR TITLE
Bump literalizer to 2026.3.20, add languages and format options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.3.20``.
+- Added support for Mojo and YAML languages.
+- Added ``:sequence-format:`` directive option for choosing between
+  tuple, list, and array output formats (supported by Crystal, Elixir,
+  Erlang, Julia, and Python).
+- Added ``:set-format:`` directive option for choosing between set and
+  frozenset output (Python only).
+- Added ``:bytes-format:`` directive option for choosing between hex and
+  Python bytes output (Python only).
+
 2026.03.19
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,9 +41,14 @@ Directive options
 
 ``:language:`` (required)
    Target language name (Pygments language name).
-   Supported values: ``clojure``, ``cpp``, ``csharp``, ``dart``, ``go``,
-   ``java``, ``javascript``, ``julia``, ``kotlin``, ``php``, ``python``,
-   ``r``, ``ruby``, ``scala``, ``swift``, ``typescript``.
+   Supported values: ``ada``, ``bash``, ``c``, ``clojure``, ``cobol``,
+   ``common-lisp``, ``cpp``, ``crystal``, ``csharp``, ``d``, ``dart``,
+   ``elixir``, ``erlang``, ``fsharp``, ``go``, ``groovy``, ``haskell``,
+   ``hcl``, ``java``, ``javascript``, ``julia``, ``kotlin``, ``lua``,
+   ``matlab``, ``mojo``, ``nim``, ``ocaml``, ``occam``, ``perl``, ``php``,
+   ``powershell``, ``python``, ``r``, ``racket``, ``ruby``, ``rust``,
+   ``scala``, ``swift``, ``toml``, ``typescript``, ``visual-basic``,
+   ``yaml``, ``zig``.
 
 ``:prefix:`` (optional)
    Number of whitespace characters to prepend to each output line.
@@ -95,6 +100,36 @@ Directive options
       ``Date(...)`` / ``DateTime(...)`` constructors.
    ``r``
       ``as.Date(...)`` / ``as.POSIXct(...)`` calls.
+
+``:sequence-format:`` (optional)
+   How to render sequences (arrays/lists).  Not all values are valid for
+   every language.  Supported values:
+
+   ``tuple``
+      Tuple delimiters.  Available for Crystal, Elixir, Erlang, Julia,
+      and Python (default for Python).
+   ``list``
+      List delimiters.  Available for Elixir (default), Erlang (default),
+      and Python.
+   ``array``
+      Array delimiters.  Available for Crystal (default) and Julia
+      (default).
+
+``:set-format:`` (optional)
+   How to render sets (Python only).  Supported values:
+
+   ``set``
+      ``{`` … ``}`` set literal (default).
+   ``frozenset``
+      ``frozenset({`` … ``})`` constructor.
+
+``:bytes-format:`` (optional)
+   How to render binary data (Python only).  Supported values:
+
+   ``hex``
+      Hex-escaped bytes literal, e.g. ``b"\x48\x65"`` (default).
+   ``python``
+      Python bytes literal, e.g. ``b"Hello"``.
 
 ``:variable-name:`` (optional)
    Wrap the output in a variable declaration or assignment using the given

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "docutils",
-    "literalizer==2026.3.19.1",
+    "literalizer==2026.3.20",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,7 +1,10 @@
 Changelog
 Lua
+Mojo
+Nim
 OCaml
 Pygments
+Zig
 datetimes
 dicts
 literalizer

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -36,6 +36,7 @@ from literalizer.languages import (
     Kotlin,
     Lua,
     Matlab,
+    Mojo,
     Nim,
     OCaml,
     Occam,
@@ -52,6 +53,7 @@ from literalizer.languages import (
     Toml,
     TypeScript,
     VisualBasic,
+    Yaml,
     Zig,
 )
 from sphinx.application import Sphinx
@@ -83,6 +85,7 @@ _LANGUAGE_TYPES: dict[str, type[Language]] = {
     "kotlin": Kotlin,
     "lua": Lua,
     "matlab": Matlab,
+    "mojo": Mojo,
     "nim": Nim,
     "ocaml": OCaml,
     "occam": Occam,
@@ -99,6 +102,7 @@ _LANGUAGE_TYPES: dict[str, type[Language]] = {
     "toml": Toml,
     "typescript": TypeScript,
     "visual-basic": VisualBasic,
+    "yaml": Yaml,
     "zig": Zig,
 }
 
@@ -163,6 +167,76 @@ _DATE_FORMAT_KWARGS: dict[str, dict[str, Any]] = {
     },
 }
 
+_SEQUENCE_FORMAT_KWARGS: dict[
+    tuple[str, str],
+    dict[str, Any],
+] = {
+    ("crystal", "array"): {
+        "sequence_format": Crystal.SequenceFormat.ARRAY,
+    },
+    ("crystal", "tuple"): {
+        "sequence_format": Crystal.SequenceFormat.TUPLE,
+    },
+    ("elixir", "list"): {
+        "sequence_format": Elixir.SequenceFormat.LIST,
+    },
+    ("elixir", "tuple"): {
+        "sequence_format": Elixir.SequenceFormat.TUPLE,
+    },
+    ("erlang", "list"): {
+        "sequence_format": Erlang.SequenceFormat.LIST,
+    },
+    ("erlang", "tuple"): {
+        "sequence_format": Erlang.SequenceFormat.TUPLE,
+    },
+    ("julia", "array"): {
+        "sequence_format": Julia.SequenceFormat.ARRAY,
+    },
+    ("julia", "tuple"): {
+        "sequence_format": Julia.SequenceFormat.TUPLE,
+    },
+    ("python", "list"): {
+        "sequence_format": Python.SequenceFormat.LIST,
+    },
+    ("python", "tuple"): {
+        "sequence_format": Python.SequenceFormat.TUPLE,
+    },
+}
+
+_SEQUENCE_FORMAT_VALUES: tuple[str, ...] = (
+    "array",
+    "list",
+    "tuple",
+)
+
+_SET_FORMAT_KWARGS: dict[tuple[str, str], dict[str, Any]] = {
+    ("python", "frozenset"): {
+        "set_format": Python.SetFormat.FROZENSET,
+    },
+    ("python", "set"): {
+        "set_format": Python.SetFormat.SET,
+    },
+}
+
+_SET_FORMAT_VALUES: tuple[str, ...] = (
+    "frozenset",
+    "set",
+)
+
+_BYTES_FORMAT_KWARGS: dict[tuple[str, str], dict[str, Any]] = {
+    ("python", "hex"): {
+        "bytes_format": Python.BytesFormat.HEX,
+    },
+    ("python", "python"): {
+        "bytes_format": Python.BytesFormat.PYTHON,
+    },
+}
+
+_BYTES_FORMAT_VALUES: tuple[str, ...] = (
+    "hex",
+    "python",
+)
+
 
 class LiteralizerDirective(SphinxDirective):
     """Directive that converts a JSON file to a native literal block.
@@ -177,6 +251,9 @@ class LiteralizerDirective(SphinxDirective):
            :wrap:
            :variable-name: my_var
            :existing-variable:
+           :sequence-format: list
+           :set-format: frozenset
+           :bytes-format: python
     """
 
     required_arguments = 1
@@ -196,6 +273,18 @@ class LiteralizerDirective(SphinxDirective):
         ),
         "variable-name": directives.unchanged,
         "existing-variable": directives.flag,
+        "sequence-format": lambda x: directives.choice(
+            argument=x,
+            values=_SEQUENCE_FORMAT_VALUES,
+        ),
+        "set-format": lambda x: directives.choice(
+            argument=x,
+            values=_SET_FORMAT_VALUES,
+        ),
+        "bytes-format": lambda x: directives.choice(
+            argument=x,
+            values=_BYTES_FORMAT_VALUES,
+        ),
     }
 
     def run(self) -> list[nodes.Node]:
@@ -208,14 +297,30 @@ class LiteralizerDirective(SphinxDirective):
         env.note_dependency(str(object=data_path))
 
         language_name: str = self.options["language"]
+        language_cls = _LANGUAGE_TYPES[language_name]
+        format_kwargs: dict[str, Any] = {}
+
         date_format_name: str | None = self.options.get("date-format")
         if date_format_name is not None:
-            date_format_kwargs = _DATE_FORMAT_KWARGS[date_format_name]
-        else:
-            date_format_kwargs = {}
-        language_spec: Language = _LANGUAGE_TYPES[language_name](
-            **date_format_kwargs
-        )
+            format_kwargs.update(_DATE_FORMAT_KWARGS[date_format_name])
+
+        seq_fmt: str | None = self.options.get("sequence-format")
+        if seq_fmt is not None:
+            format_kwargs.update(
+                _SEQUENCE_FORMAT_KWARGS[(language_name, seq_fmt)]
+            )
+
+        set_fmt: str | None = self.options.get("set-format")
+        if set_fmt is not None:
+            format_kwargs.update(_SET_FORMAT_KWARGS[(language_name, set_fmt)])
+
+        bytes_fmt: str | None = self.options.get("bytes-format")
+        if bytes_fmt is not None:
+            format_kwargs.update(
+                _BYTES_FORMAT_KWARGS[(language_name, bytes_fmt)]
+            )
+
+        language_spec: Language = language_cls(**format_kwargs)
         prefix_count: int = self.options.get("prefix", 0)
         prefix_char_name: str = self.options.get("prefix-char", "spaces")
         prefix_char = "\t" if prefix_char_name == "tabs" else " "

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1139,3 +1139,421 @@ def test_no_wrap_by_default(
     expected_app.cleanup()
 
     assert content_html == expected_html
+
+
+def test_mojo_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the mojo language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: mojo
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: mojo
+
+           1,
+           2,
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_yaml_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the yaml language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: yaml
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    (source_directory / "expected.yaml").write_text(data="1,\n2\n")
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalinclude:: expected.yaml
+           :language: yaml
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_sequence_format_list_python(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :sequence-format: list option uses list delimiters for
+    Python.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :wrap:
+           :sequence-format: list
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           [
+               1,
+               2,
+           ]
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_sequence_format_tuple_python(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :sequence-format: tuple option (Python default) uses tuple
+    delimiters.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :wrap:
+           :sequence-format: tuple
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           (
+               1,
+               2,
+           )
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_set_format_frozenset_python(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :set-format: frozenset option uses frozenset for Python."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(
+        data=dedent(
+            text="""\
+            !!set
+            a: null
+            b: null
+        """
+        )
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: python
+           :wrap:
+           :set-format: frozenset
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    # Without frozenset option (default set) should differ
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: python
+           :wrap:
+           :set-format: set
+    """
+        )
+    )
+    set_app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    set_app.build()
+    assert set_app.statuscode == 0
+    set_html = (set_app.outdir / "index.html").read_text()
+    set_app.cleanup()
+
+    assert content_html != set_html
+
+
+def test_bytes_format_python(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :bytes-format: option changes Python bytes formatting."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(
+        data=dedent(
+            text="""\
+            !!binary |
+              SGVsbG8=
+        """
+        )
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: python
+           :bytes-format: hex
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    hex_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: python
+           :bytes-format: python
+    """
+        )
+    )
+    python_app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    python_app.build()
+    assert python_app.statuscode == 0
+    python_html = (python_app.outdir / "index.html").read_text()
+    python_app.cleanup()
+
+    assert hex_html != python_html
+
+
+def test_sequence_format_tuple_elixir(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :sequence-format: tuple option works for Elixir."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: elixir
+           :wrap:
+           :sequence-format: tuple
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    tuple_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: elixir
+           :wrap:
+           :sequence-format: list
+    """
+        )
+    )
+    list_app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    list_app.build()
+    assert list_app.statuscode == 0
+    list_html = (list_app.outdir / "index.html").read_text()
+    list_app.cleanup()
+
+    assert tuple_html != list_html

--- a/uv.lock
+++ b/uv.lock
@@ -605,16 +605,16 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.3.19.1"
+version = "2026.3.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "json-to-schema" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/a0/2c5996a6e5d751a77475c30ac3007b68f75ff1ac44ff9c9c53247747e75b/literalizer-2026.3.19.1.tar.gz", hash = "sha256:7066aa8ad1d8ed0b0dfe6f1955beaf54eaf1e93c043eddd4362f3e6ca97d3e08", size = 354742, upload-time = "2026-03-19T16:19:10.677Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/10/b4c7b760cb727237a5d14cef62ad7f9d1d232542bb29bdbf2c74fc3fca36/literalizer-2026.3.20.tar.gz", hash = "sha256:ce491f81604fb82bc033b99856946aa42dcded25af23ec92003b7fb8469f0df5", size = 365055, upload-time = "2026-03-20T11:47:03.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/49/bae2e89b661ec50d07ef4e8e56c77954b8d804fb5d18303bbd0112cee84f/literalizer-2026.3.19.1-py3-none-any.whl", hash = "sha256:070b6c2412865e592b492325595e08e481cb11f874fa1150013c89a1853d91e5", size = 80455, upload-time = "2026-03-19T16:19:09.031Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a1/fd4d29810fb3db6f2e65f3ed940c289f0ff7dbda8d0c1e0d3bb2347202fe/literalizer-2026.3.20-py3-none-any.whl", hash = "sha256:f4dbb6fba4b7bde37c4e60a1556fec13d561ba584312ac988c9481d04bb18e25", size = 84940, upload-time = "2026-03-20T11:47:00.915Z" },
 ]
 
 [[package]]
@@ -1549,7 +1549,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.3.19.1" },
+    { name = "literalizer", specifier = "==2026.3.20" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.6" },


### PR DESCRIPTION
## Summary
- Bumps literalizer from 2026.3.19.1 to 2026.3.20
- Adds new languages: Mojo and Yaml
- Adds new directive options for output type choices: `:sequence-format:` (tuple/list/array), `:set-format:` (set/frozenset), `:bytes-format:` (hex/python)
- These expose literalizer's format choice enums, allowing users to control how sequences, sets, and bytes are rendered per language

## Test plan
- [x] All 20 existing tests pass
- [x] 7 new tests added covering Mojo, Yaml, sequence-format, set-format, bytes-format, and cross-language sequence-format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes directive option parsing and language instantiation; invalid language/format combinations can now raise mapping `KeyError`s at build time if not covered by validation/tests.
> 
> **Overview**
> Bumps the `literalizer` dependency to `2026.3.20` and updates lockfiles/changelog accordingly.
> 
> Extends the `literalizer` directive to support **Mojo** and **YAML** output, and adds new formatting options (`:sequence-format:`, `:set-format:`, `:bytes-format:`) that map to `literalizer` enums when constructing the target `Language`.
> 
> Updates docs/spelling lists and adds integration tests covering the new languages plus the new format options (including differing outputs for Python and Elixir).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71ece38f0db645203281b16cffb24a80bec0c026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->