### PR TITLE
Bump literalizer to 2026.3.20.1, add languages and Rust sequence formats

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,9 @@ Changelog
 Next
 ----
 
-- Bumped ``literalizer`` to ``2026.3.20``.
-- Added support for Mojo and YAML languages.
-- Added ``:sequence-format:`` directive option for choosing between
-  tuple, list, and array output formats (supported by Crystal, Elixir,
-  Erlang, Julia, and Python).
-- Added ``:set-format:`` directive option for choosing between set and
-  frozenset output (Python only).
-- Added ``:bytes-format:`` directive option for choosing between hex and
-  Python bytes output (Python only).
+- Bumped ``literalizer`` to ``2026.3.20.1``.
+- Added support for Fortran and Norg languages.
+- Added ``vec`` and ``tuple`` sequence format options for Rust.
 
 2026.03.19
 ----------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,9 +43,10 @@ Directive options
    Target language name (Pygments language name).
    Supported values: ``ada``, ``bash``, ``c``, ``clojure``, ``cobol``,
    ``common-lisp``, ``cpp``, ``crystal``, ``csharp``, ``d``, ``dart``,
-   ``elixir``, ``erlang``, ``fsharp``, ``go``, ``groovy``, ``haskell``,
-   ``hcl``, ``java``, ``javascript``, ``julia``, ``kotlin``, ``lua``,
-   ``matlab``, ``mojo``, ``nim``, ``ocaml``, ``occam``, ``perl``, ``php``,
+   ``elixir``, ``erlang``, ``fortran``, ``fsharp``, ``go``, ``groovy``,
+   ``haskell``, ``hcl``, ``java``, ``javascript``, ``julia``, ``kotlin``,
+   ``lua``, ``matlab``, ``mojo``, ``nim``, ``norg``, ``ocaml``, ``occam``,
+   ``perl``, ``php``,
    ``powershell``, ``python``, ``r``, ``racket``, ``ruby``, ``rust``,
    ``scala``, ``swift``, ``toml``, ``typescript``, ``visual-basic``,
    ``yaml``, ``zig``.
@@ -107,13 +108,15 @@ Directive options
 
    ``tuple``
       Tuple delimiters.  Available for Crystal, Elixir, Erlang, Julia,
-      and Python (default for Python).
+      Python (default for Python), and Rust.
    ``list``
       List delimiters.  Available for Elixir (default), Erlang (default),
       and Python.
    ``array``
       Array delimiters.  Available for Crystal (default) and Julia
       (default).
+   ``vec``
+      Vec macro (``vec![...]``).  Available for Rust (default).
 
 ``:set-format:`` (optional)
    How to render sets (Python only).  Supported values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "docutils",
-    "literalizer==2026.3.20",
+    "literalizer==2026.3.20.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,9 +1,12 @@
 Changelog
+Fortran
 Lua
 Mojo
 Nim
+Norg
 OCaml
 Pygments
+Vec
 Zig
 datetimes
 dicts

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -25,6 +25,7 @@ from literalizer.languages import (
     Dart,
     Elixir,
     Erlang,
+    Fortran,
     FSharp,
     Go,
     Groovy,
@@ -38,6 +39,7 @@ from literalizer.languages import (
     Matlab,
     Mojo,
     Nim,
+    Norg,
     OCaml,
     Occam,
     Perl,
@@ -74,6 +76,7 @@ _LANGUAGE_TYPES: dict[str, type[Language]] = {
     "dart": Dart,
     "elixir": Elixir,
     "erlang": Erlang,
+    "fortran": Fortran,
     "fsharp": FSharp,
     "go": Go,
     "groovy": Groovy,
@@ -87,6 +90,7 @@ _LANGUAGE_TYPES: dict[str, type[Language]] = {
     "matlab": Matlab,
     "mojo": Mojo,
     "nim": Nim,
+    "norg": Norg,
     "ocaml": OCaml,
     "occam": Occam,
     "perl": Perl,
@@ -201,12 +205,19 @@ _SEQUENCE_FORMAT_KWARGS: dict[
     ("python", "tuple"): {
         "sequence_format": Python.SequenceFormat.TUPLE,
     },
+    ("rust", "tuple"): {
+        "sequence_format": Rust.SequenceFormat.TUPLE,
+    },
+    ("rust", "vec"): {
+        "sequence_format": Rust.SequenceFormat.VEC,
+    },
 }
 
 _SEQUENCE_FORMAT_VALUES: tuple[str, ...] = (
     "array",
     "list",
     "tuple",
+    "vec",
 )
 
 _SET_FORMAT_KWARGS: dict[tuple[str, str], dict[str, Any]] = {

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1500,6 +1500,112 @@ def test_bytes_format_python(
     assert hex_html != python_html
 
 
+def test_fortran_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the fortran language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: fortran
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    (source_directory / "expected.f90").write_text(data="fint(1),\nfint(2)\n")
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalinclude:: expected.f90
+           :language: fortran
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_norg_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the norg language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: norg
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    (source_directory / "expected.norg").write_text(data="1,\n2\n")
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalinclude:: expected.norg
+           :language: norg
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
 def test_sequence_format_tuple_elixir(
     *,
     make_app: Callable[..., SphinxTestApp],
@@ -1557,3 +1663,62 @@ def test_sequence_format_tuple_elixir(
     list_app.cleanup()
 
     assert tuple_html != list_html
+
+
+def test_sequence_format_tuple_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :sequence-format: tuple option works for Rust."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :wrap:
+           :sequence-format: tuple
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    tuple_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :wrap:
+           :sequence-format: vec
+    """
+        )
+    )
+    vec_app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    vec_app.build()
+    assert vec_app.statuscode == 0
+    vec_html = (vec_app.outdir / "index.html").read_text()
+    vec_app.cleanup()
+
+    assert tuple_html != vec_html

--- a/uv.lock
+++ b/uv.lock
@@ -605,16 +605,16 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.3.20"
+version = "2026.3.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "json-to-schema" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/10/b4c7b760cb727237a5d14cef62ad7f9d1d232542bb29bdbf2c74fc3fca36/literalizer-2026.3.20.tar.gz", hash = "sha256:ce491f81604fb82bc033b99856946aa42dcded25af23ec92003b7fb8469f0df5", size = 365055, upload-time = "2026-03-20T11:47:03.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/a2/8638f383a2eaac8a9d3092c46f60b051684032f458954a00e9bbb46c850f/literalizer-2026.3.20.1.tar.gz", hash = "sha256:616cdd1dc002394a01496f59ada8167e2764917f97cb7fa03c3e936d3de04afd", size = 391549, upload-time = "2026-03-20T12:38:05.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/a1/fd4d29810fb3db6f2e65f3ed940c289f0ff7dbda8d0c1e0d3bb2347202fe/literalizer-2026.3.20-py3-none-any.whl", hash = "sha256:f4dbb6fba4b7bde37c4e60a1556fec13d561ba584312ac988c9481d04bb18e25", size = 84940, upload-time = "2026-03-20T11:47:00.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/80/71c7c81192f0d1bed0cd29877b809a7ead3e881595e6cf090206092b6fbc/literalizer-2026.3.20.1-py3-none-any.whl", hash = "sha256:61967644308f3c4e2dc42b73ca2d0e4a93ed8609ac69fc33b5ea7dfb4a1bfdce", size = 88696, upload-time = "2026-03-20T12:38:03.887Z" },
 ]
 
 [[package]]
@@ -1549,7 +1549,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.3.20" },
+    { name = "literalizer", specifier = "==2026.3.20.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.6" },


### PR DESCRIPTION
## Summary
- Bumps `literalizer` from `2026.3.20` to `2026.3.20.1`.
- Adds support for Fortran and Norg languages.
- Adds `vec` (default) and `tuple` sequence format options for Rust.
- Updates docs, changelog, and adds tests for all new features.

## Test plan
- [x] All 30 tests pass, including new tests for Fortran, Norg, and Rust sequence formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to a dependency bump and changes to directive option handling for additional languages/sequence formats, which could affect rendered output. Added integration tests reduce regression likelihood.
> 
> **Overview**
> Bumps the pinned `literalizer` dependency to `2026.3.20.1` and updates the lockfile accordingly.
> 
> Extends the `:language:` option to support **Fortran** and **Norg**, and adds Rust `:sequence-format:` support for `vec` (default) and `tuple` by wiring new format kwargs in `sphinx_literalizer/__init__.py`.
> 
> Updates docs/changelog/spelling dictionary to reflect the new options and adds integration tests covering Fortran/Norg rendering and Rust `vec` vs `tuple` output differences.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11bd3ac81cec771dff611cb7f2a49dc736231608. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->