### PR TITLE
Bump literalizer to 2026.3.20.2, add Objective-C and sequence format defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Changelog
 Next
 ----
 
+2026.03.20.1
+------------
+
+
+- Bumped ``literalizer`` to ``2026.3.20.2``.
+- Added support for Objective-C language.
+- Added ``array`` sequence format option for Rust.
+- Added ``sequence_format`` as a required field for all languages.
+  New sequence format values: ``cell_array``, ``initializer_list``,
+  ``sequence``, ``slice``, ``table``, ``vector``.
+
 2026.03.20
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,8 +45,8 @@ Directive options
    ``common-lisp``, ``cpp``, ``crystal``, ``csharp``, ``d``, ``dart``,
    ``elixir``, ``erlang``, ``fortran``, ``fsharp``, ``go``, ``groovy``,
    ``haskell``, ``hcl``, ``java``, ``javascript``, ``julia``, ``kotlin``,
-   ``lua``, ``matlab``, ``mojo``, ``nim``, ``norg``, ``ocaml``, ``occam``,
-   ``perl``, ``php``,
+   ``lua``, ``matlab``, ``mojo``, ``nim``, ``norg``, ``objective-c``,
+   ``ocaml``, ``occam``, ``perl``, ``php``,
    ``powershell``, ``python``, ``r``, ``racket``, ``ruby``, ``rust``,
    ``scala``, ``swift``, ``toml``, ``typescript``, ``visual-basic``,
    ``yaml``, ``zig``.
@@ -106,17 +106,30 @@ Directive options
    How to render sequences (arrays/lists).  Not all values are valid for
    every language.  Supported values:
 
+   ``array``
+      Array delimiters.  Available for Crystal (default), Julia (default),
+      Rust, and many other languages.
+   ``cell_array``
+      Cell array delimiters.  Available for MATLAB (default).
+   ``initializer_list``
+      Initializer list.  Available for C++ (default).
+   ``list``
+      List delimiters.  Available for Elixir (default), Erlang (default),
+      Python, and many other languages.
+   ``sequence``
+      Sequence delimiters.  Available for COBOL (default) and YAML
+      (default).
+   ``slice``
+      Slice delimiters.  Available for Go (default).
+   ``table``
+      Table delimiters.  Available for Lua (default).
    ``tuple``
       Tuple delimiters.  Available for Crystal, Elixir, Erlang, Julia,
       Python (default for Python), and Rust.
-   ``list``
-      List delimiters.  Available for Elixir (default), Erlang (default),
-      and Python.
-   ``array``
-      Array delimiters.  Available for Crystal (default) and Julia
-      (default).
    ``vec``
       Vec macro (``vec![...]``).  Available for Rust (default).
+   ``vector``
+      Vector delimiters.  Available for Clojure (default).
 
 ``:set-format:`` (optional)
    How to render sets (Python only).  Supported values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = [
 ]
 dependencies = [
     "docutils",
-    "literalizer==2026.3.20.1",
+    "literalizer==2026.3.20.2",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,6 +1,7 @@
 COBOL
 Changelog
 Fortran
+Initializer
 Lua
 MATLAB
 Mojo

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -1,6 +1,8 @@
+COBOL
 Changelog
 Fortran
 Lua
+MATLAB
 Mojo
 Nim
 Norg

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -239,15 +239,20 @@ _DATE_FORMATS: dict[str, _DateFormats] = {
     ),
 }
 
-_DEFAULT_EXTRA_KWARGS: dict[str, dict[str, Any]] = {
-    "python": {
-        "bytes_format": Python.BytesFormat.HEX,
-        "set_format": Python.SetFormat.SET,
-        "variable_type_hints": Python.VariableTypeHints.NONE,
-    },
-    "r": {
-        "empty_dict_key": R.EmptyDictKey.ERROR,
-    },
+_DEFAULT_BYTES_FORMATS: dict[str, object] = {
+    "python": Python.BytesFormat.HEX,
+}
+
+_DEFAULT_SET_FORMATS: dict[str, object] = {
+    "python": Python.SetFormat.SET,
+}
+
+_DEFAULT_VARIABLE_TYPE_HINTS: dict[str, object] = {
+    "python": Python.VariableTypeHints.NONE,
+}
+
+_DEFAULT_EMPTY_DICT_KEYS: dict[str, object] = {
+    "r": R.EmptyDictKey.ERROR,
 }
 
 _DEFAULT_SEQUENCE_FORMATS: dict[str, object] = {
@@ -349,6 +354,75 @@ _BYTES_FORMAT_VALUES: tuple[str, ...] = (
 )
 
 
+def _apply_date_formats(
+    constructor: partial[Language],
+    date_formats: _DateFormats,
+) -> partial[Language]:
+    """Apply date and datetime format options to a constructor."""
+    if date_formats.date_format is not None:
+        constructor = partial(
+            constructor,
+            date_format=date_formats.date_format,
+        )
+    if date_formats.datetime_format is not None:
+        constructor = partial(
+            constructor,
+            datetime_format=date_formats.datetime_format,
+        )
+    return constructor
+
+
+def _default_constructor(
+    language_name: str,
+) -> partial[Language]:
+    """Build a language constructor with sensible defaults applied."""
+    language_cls = _LANGUAGE_TYPES[language_name]
+    constructor = partial(language_cls)
+    constructor = partial(
+        constructor,
+        sequence_format=_DEFAULT_SEQUENCE_FORMATS[language_name],
+    )
+
+    default_date_formats = _DEFAULT_DATE_FORMATS.get(language_name)
+    if default_date_formats is not None:
+        constructor = _apply_date_formats(
+            constructor=constructor,
+            date_formats=default_date_formats,
+        )
+
+    default_bytes_format = _DEFAULT_BYTES_FORMATS.get(language_name)
+    if default_bytes_format is not None:
+        constructor = partial(
+            constructor,
+            bytes_format=default_bytes_format,
+        )
+
+    default_set_format = _DEFAULT_SET_FORMATS.get(language_name)
+    if default_set_format is not None:
+        constructor = partial(
+            constructor,
+            set_format=default_set_format,
+        )
+
+    default_variable_type_hints = _DEFAULT_VARIABLE_TYPE_HINTS.get(
+        language_name,
+    )
+    if default_variable_type_hints is not None:
+        constructor = partial(
+            constructor,
+            variable_type_hints=default_variable_type_hints,
+        )
+
+    default_empty_dict_key = _DEFAULT_EMPTY_DICT_KEYS.get(language_name)
+    if default_empty_dict_key is not None:
+        constructor = partial(
+            constructor,
+            empty_dict_key=default_empty_dict_key,
+        )
+
+    return constructor
+
+
 class LiteralizerDirective(SphinxDirective):
     """Directive that converts a JSON file to a native literal block.
 
@@ -408,43 +482,14 @@ class LiteralizerDirective(SphinxDirective):
         env.note_dependency(str(object=data_path))
 
         language_name: str = self.options["language"]
-        language_cls = _LANGUAGE_TYPES[language_name]
-        constructor = partial(language_cls)
-        constructor = partial(
-            constructor,
-            sequence_format=_DEFAULT_SEQUENCE_FORMATS[language_name],
-        )
-
-        default_date_formats = _DEFAULT_DATE_FORMATS.get(language_name)
-        if default_date_formats is not None:
-            if default_date_formats.date_format is not None:
-                constructor = partial(
-                    constructor,
-                    date_format=default_date_formats.date_format,
-                )
-            if default_date_formats.datetime_format is not None:
-                constructor = partial(
-                    constructor,
-                    datetime_format=default_date_formats.datetime_format,
-                )
-
-        default_extra_kwargs = _DEFAULT_EXTRA_KWARGS.get(language_name)
-        if default_extra_kwargs is not None:
-            constructor = partial(constructor, **default_extra_kwargs)
+        constructor = _default_constructor(language_name=language_name)
 
         date_format_name: str | None = self.options.get("date-format")
         if date_format_name is not None:
-            date_formats = _DATE_FORMATS[date_format_name]
-            if date_formats.date_format is not None:
-                constructor = partial(
-                    constructor,
-                    date_format=date_formats.date_format,
-                )
-            if date_formats.datetime_format is not None:
-                constructor = partial(
-                    constructor,
-                    datetime_format=date_formats.datetime_format,
-                )
+            constructor = _apply_date_formats(
+                constructor=constructor,
+                date_formats=_DATE_FORMATS[date_format_name],
+            )
 
         seq_fmt: str | None = self.options.get("sequence-format")
         if seq_fmt is not None:

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -40,6 +40,7 @@ from literalizer.languages import (
     Mojo,
     Nim,
     Norg,
+    ObjectiveC,
     OCaml,
     Occam,
     Perl,
@@ -91,6 +92,7 @@ _LANGUAGE_TYPES: dict[str, type[Language]] = {
     "mojo": Mojo,
     "nim": Nim,
     "norg": Norg,
+    "objective-c": ObjectiveC,
     "ocaml": OCaml,
     "occam": Occam,
     "perl": Perl,
@@ -108,6 +110,61 @@ _LANGUAGE_TYPES: dict[str, type[Language]] = {
     "visual-basic": VisualBasic,
     "yaml": Yaml,
     "zig": Zig,
+}
+
+_DEFAULT_DATE_FORMAT_KWARGS: dict[str, dict[str, Any]] = {
+    "cpp": {
+        "date_format": Cpp.DateFormat.ISO,
+        "datetime_format": Cpp.DatetimeFormat.ISO,
+    },
+    "csharp": {
+        "date_format": CSharp.DateFormat.ISO,
+        "datetime_format": CSharp.DatetimeFormat.ISO,
+    },
+    "dart": {
+        "date_format": Dart.DateFormat.ISO,
+        "datetime_format": Dart.DatetimeFormat.ISO,
+    },
+    "go": {
+        "date_format": Go.DateFormat.ISO,
+        "datetime_format": Go.DatetimeFormat.ISO,
+    },
+    "java": {
+        "date_format": Java.DateFormat.ISO,
+        "datetime_format": Java.DatetimeFormat.ISO,
+    },
+    "javascript": {
+        "date_format": JavaScript.DateFormat.ISO,
+        "datetime_format": JavaScript.DatetimeFormat.ISO,
+    },
+    "julia": {
+        "date_format": Julia.DateFormat.ISO,
+        "datetime_format": Julia.DatetimeFormat.ISO,
+    },
+    "kotlin": {
+        "date_format": Kotlin.DateFormat.ISO,
+        "datetime_format": Kotlin.DatetimeFormat.ISO,
+    },
+    "python": {
+        "date_format": Python.DateFormat.ISO,
+        "datetime_format": Python.DatetimeFormat.ISO,
+    },
+    "r": {
+        "date_format": R.DateFormat.ISO,
+        "datetime_format": R.DatetimeFormat.ISO,
+    },
+    "ruby": {
+        "date_format": Ruby.DateFormat.ISO,
+        "datetime_format": Ruby.DatetimeFormat.ISO,
+    },
+    "rust": {
+        "date_format": Rust.DateFormat.ISO,
+        "datetime_format": Rust.DatetimeFormat.ISO,
+    },
+    "typescript": {
+        "date_format": TypeScript.DateFormat.ISO,
+        "datetime_format": TypeScript.DatetimeFormat.ISO,
+    },
 }
 
 _DATE_FORMAT_KWARGS: dict[str, dict[str, Any]] = {
@@ -171,6 +228,80 @@ _DATE_FORMAT_KWARGS: dict[str, dict[str, Any]] = {
     },
 }
 
+_DEFAULT_EXTRA_KWARGS: dict[str, dict[str, Any]] = {
+    "python": {
+        "bytes_format": Python.BytesFormat.HEX,
+        "set_format": Python.SetFormat.SET,
+        "variable_type_hints": Python.VariableTypeHints.NONE,
+    },
+    "r": {
+        "empty_dict_key": R.EmptyDictKey.ERROR,
+    },
+}
+
+_DEFAULT_SEQUENCE_FORMAT_KWARGS: dict[str, dict[str, Any]] = {
+    "ada": {"sequence_format": Ada.SequenceFormat.LIST},
+    "bash": {"sequence_format": Bash.SequenceFormat.ARRAY},
+    "c": {"sequence_format": C.SequenceFormat.ARRAY},
+    "clojure": {"sequence_format": Clojure.SequenceFormat.VECTOR},
+    "cobol": {"sequence_format": Cobol.SequenceFormat.SEQUENCE},
+    "common-lisp": {
+        "sequence_format": CommonLisp.SequenceFormat.LIST,
+    },
+    "cpp": {
+        "sequence_format": Cpp.SequenceFormat.INITIALIZER_LIST,
+    },
+    "crystal": {"sequence_format": Crystal.SequenceFormat.ARRAY},
+    "csharp": {"sequence_format": CSharp.SequenceFormat.ARRAY},
+    "d": {"sequence_format": D.SequenceFormat.ARRAY},
+    "dart": {"sequence_format": Dart.SequenceFormat.LIST},
+    "elixir": {"sequence_format": Elixir.SequenceFormat.LIST},
+    "erlang": {"sequence_format": Erlang.SequenceFormat.LIST},
+    "fortran": {"sequence_format": Fortran.SequenceFormat.LIST},
+    "fsharp": {"sequence_format": FSharp.SequenceFormat.LIST},
+    "go": {"sequence_format": Go.SequenceFormat.SLICE},
+    "groovy": {"sequence_format": Groovy.SequenceFormat.LIST},
+    "haskell": {"sequence_format": Haskell.SequenceFormat.LIST},
+    "hcl": {"sequence_format": Hcl.SequenceFormat.LIST},
+    "java": {"sequence_format": Java.SequenceFormat.ARRAY},
+    "javascript": {
+        "sequence_format": JavaScript.SequenceFormat.ARRAY,
+    },
+    "julia": {"sequence_format": Julia.SequenceFormat.ARRAY},
+    "kotlin": {"sequence_format": Kotlin.SequenceFormat.LIST},
+    "lua": {"sequence_format": Lua.SequenceFormat.TABLE},
+    "matlab": {"sequence_format": Matlab.SequenceFormat.CELL_ARRAY},
+    "mojo": {"sequence_format": Mojo.SequenceFormat.LIST},
+    "nim": {"sequence_format": Nim.SequenceFormat.ARRAY},
+    "norg": {"sequence_format": Norg.SequenceFormat.ARRAY},
+    "objective-c": {
+        "sequence_format": ObjectiveC.SequenceFormat.ARRAY,
+    },
+    "ocaml": {"sequence_format": OCaml.SequenceFormat.LIST},
+    "occam": {"sequence_format": Occam.SequenceFormat.LIST},
+    "perl": {"sequence_format": Perl.SequenceFormat.ARRAY},
+    "php": {"sequence_format": Php.SequenceFormat.ARRAY},
+    "powershell": {
+        "sequence_format": PowerShell.SequenceFormat.ARRAY,
+    },
+    "python": {"sequence_format": Python.SequenceFormat.TUPLE},
+    "r": {"sequence_format": R.SequenceFormat.LIST},
+    "racket": {"sequence_format": Racket.SequenceFormat.LIST},
+    "ruby": {"sequence_format": Ruby.SequenceFormat.ARRAY},
+    "rust": {"sequence_format": Rust.SequenceFormat.VEC},
+    "scala": {"sequence_format": Scala.SequenceFormat.LIST},
+    "swift": {"sequence_format": Swift.SequenceFormat.ARRAY},
+    "toml": {"sequence_format": Toml.SequenceFormat.ARRAY},
+    "typescript": {
+        "sequence_format": TypeScript.SequenceFormat.ARRAY,
+    },
+    "visual-basic": {
+        "sequence_format": VisualBasic.SequenceFormat.ARRAY,
+    },
+    "yaml": {"sequence_format": Yaml.SequenceFormat.SEQUENCE},
+    "zig": {"sequence_format": Zig.SequenceFormat.ARRAY},
+}
+
 _SEQUENCE_FORMAT_KWARGS: dict[
     tuple[str, str],
     dict[str, Any],
@@ -205,6 +336,9 @@ _SEQUENCE_FORMAT_KWARGS: dict[
     ("python", "tuple"): {
         "sequence_format": Python.SequenceFormat.TUPLE,
     },
+    ("rust", "array"): {
+        "sequence_format": Rust.SequenceFormat.ARRAY,
+    },
     ("rust", "tuple"): {
         "sequence_format": Rust.SequenceFormat.TUPLE,
     },
@@ -215,9 +349,15 @@ _SEQUENCE_FORMAT_KWARGS: dict[
 
 _SEQUENCE_FORMAT_VALUES: tuple[str, ...] = (
     "array",
+    "cell_array",
+    "initializer_list",
     "list",
+    "sequence",
+    "slice",
+    "table",
     "tuple",
     "vec",
+    "vector",
 )
 
 _SET_FORMAT_KWARGS: dict[tuple[str, str], dict[str, Any]] = {
@@ -310,6 +450,20 @@ class LiteralizerDirective(SphinxDirective):
         language_name: str = self.options["language"]
         language_cls = _LANGUAGE_TYPES[language_name]
         format_kwargs: dict[str, Any] = {}
+
+        format_kwargs.update(_DEFAULT_SEQUENCE_FORMAT_KWARGS[language_name])
+
+        default_date_kwargs = _DEFAULT_DATE_FORMAT_KWARGS.get(
+            language_name,
+        )
+        if default_date_kwargs is not None:
+            format_kwargs.update(default_date_kwargs)
+
+        default_extra_kwargs = _DEFAULT_EXTRA_KWARGS.get(
+            language_name,
+        )
+        if default_extra_kwargs is not None:
+            format_kwargs.update(default_extra_kwargs)
 
         date_format_name: str | None = self.options.get("date-format")
         if date_format_name is not None:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1957,3 +1957,57 @@ def test_sequence_format_array_rust(
     vec_app.cleanup()
 
     assert array_html != vec_html
+
+
+def test_r_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the r language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: r
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: r
+
+           1,
+           2
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1722,3 +1722,116 @@ def test_sequence_format_tuple_rust(
     vec_app.cleanup()
 
     assert tuple_html != vec_html
+
+
+def test_objective_c_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the objective-c language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: objective-c
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: objective-c
+
+           @(1),
+           @(2),
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_sequence_format_array_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :sequence-format: array option works for Rust."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :wrap:
+           :sequence-format: array
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    array_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :wrap:
+           :sequence-format: vec
+    """
+        )
+    )
+    vec_app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    vec_app.build()
+    assert vec_app.statuscode == 0
+    vec_html = (vec_app.outdir / "index.html").read_text()
+    vec_app.cleanup()
+
+    assert array_html != vec_html

--- a/uv.lock
+++ b/uv.lock
@@ -606,15 +606,15 @@ wheels = [
 [[package]]
 name = "literalizer"
 version = "2026.3.20.2"
-source = { registry = "/Users/adam/Documents/repositories/literalizer/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "json-to-schema" },
     { name = "ruamel-yaml" },
 ]
-sdist = { path = "/Users/adam/Documents/repositories/literalizer/dist/literalizer-2026.3.20.2.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/38/b74747348d465060b9d522be44f01a1ea6623ebf7666d5942b9ec8d871d8/literalizer-2026.3.20.2.tar.gz", hash = "sha256:934525ad324ade3ca430230c0d08c0fea37bef8cdfe2a20d4d819c848cf46f80", size = 415744, upload-time = "2026-03-20T17:45:26.81Z" }
 wheels = [
-    { path = "/Users/adam/Documents/repositories/literalizer/dist/literalizer-2026.3.20.2-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/34/da/8ffd462c49aa036e31e6d8c0b937d2e113ee66c998c756dc02f2cd411659/literalizer-2026.3.20.2-py3-none-any.whl", hash = "sha256:1fc1a66d187bc3cfc876a2e98994b6d1bdef39e7280e2e8bc6d8aa7ce21a44a1", size = 94265, upload-time = "2026-03-20T17:45:25.171Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -605,16 +605,16 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.3.20.1"
-source = { registry = "https://pypi.org/simple" }
+version = "2026.3.20.2"
+source = { registry = "/Users/adam/Documents/repositories/literalizer/dist" }
 dependencies = [
     { name = "beartype" },
     { name = "json-to-schema" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/a2/8638f383a2eaac8a9d3092c46f60b051684032f458954a00e9bbb46c850f/literalizer-2026.3.20.1.tar.gz", hash = "sha256:616cdd1dc002394a01496f59ada8167e2764917f97cb7fa03c3e936d3de04afd", size = 391549, upload-time = "2026-03-20T12:38:05.647Z" }
+sdist = { path = "/Users/adam/Documents/repositories/literalizer/dist/literalizer-2026.3.20.2.tar.gz" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/80/71c7c81192f0d1bed0cd29877b809a7ead3e881595e6cf090206092b6fbc/literalizer-2026.3.20.1-py3-none-any.whl", hash = "sha256:61967644308f3c4e2dc42b73ca2d0e4a93ed8609ac69fc33b5ea7dfb4a1bfdce", size = 88696, upload-time = "2026-03-20T12:38:03.887Z" },
+    { path = "/Users/adam/Documents/repositories/literalizer/dist/literalizer-2026.3.20.2-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -1549,7 +1549,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.3.20.1" },
+    { name = "literalizer", specifier = "==2026.3.20.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.6" },


### PR DESCRIPTION
## Summary
- Bumps `literalizer` dependency from `2026.3.20.1` to `2026.3.20.2`.
- Adds Objective-C language support.
- Adds Rust `array` sequence format option.
- Adapts to literalizer's new required `sequence_format` parameter on all languages by providing defaults for every language, along with defaults for other newly-required params (`date_format`, `datetime_format`, `variable_type_hints`, `empty_dict_key`).
- Adds new sequence format values: `cell_array`, `initializer_list`, `sequence`, `slice`, `table`, `vector`.

## Test plan
- [x] All 32 existing + new tests pass
- [x] New test for Objective-C language rendering
- [x] New test for Rust `array` sequence format


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how language constructors are initialized (new per-language defaults for required `literalizer` params), which can subtly alter rendered output across languages despite added coverage.
> 
> **Overview**
> Updates the extension to `literalizer==2026.3.20.2` and wires in **Objective-C** as a supported `:language:` option.
> 
> Adapts to `literalizer` making `sequence_format` required by introducing a centralized `_default_constructor()` that applies per-language defaults (and default date/bytes/set/type-hint/empty-dict-key options), while also expanding `:sequence-format:` to include new values and Rust’s `array` option.
> 
> Docs/changelog/spelling lists are updated accordingly, and new integration tests cover Objective-C rendering, Rust `:sequence-format: array`, and basic R output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ca758e80508653e8e146c8ea53b46dc21cb21d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->