### PR TITLE
Rename abbreviated format variable names

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -301,25 +301,32 @@ class LiteralizerDirective(SphinxDirective):
                     datetime_format=date_formats.datetime_format,
                 )
 
-        seq_fmt: str | None = self.options.get("sequence-format")
-        if seq_fmt is not None:
+        sequence_format_option: str | None = self.options.get(
+            "sequence-format",
+        )
+        if sequence_format_option is not None:
+            sequence_format_key = (language_name, sequence_format_option)
             constructor = partial(
                 constructor,
-                sequence_format=_SEQUENCE_FORMATS[(language_name, seq_fmt)],
+                sequence_format=_SEQUENCE_FORMATS[sequence_format_key],
             )
 
-        set_fmt: str | None = self.options.get("set-format")
-        if set_fmt is not None:
+        set_format_option: str | None = self.options.get("set-format")
+        if set_format_option is not None:
             constructor = partial(
                 constructor,
-                set_format=_SET_FORMATS[(language_name, set_fmt)],
+                set_format=_SET_FORMATS[(language_name, set_format_option)],
             )
 
-        bytes_fmt: str | None = self.options.get("bytes-format")
-        if bytes_fmt is not None:
+        bytes_format_option: str | None = self.options.get(
+            "bytes-format",
+        )
+        if bytes_format_option is not None:
             constructor = partial(
                 constructor,
-                bytes_format=_BYTES_FORMATS[(language_name, bytes_fmt)],
+                bytes_format=_BYTES_FORMATS[
+                    (language_name, bytes_format_option)
+                ],
             )
 
         language_spec: Language = constructor()


### PR DESCRIPTION
## Summary
- Rename `seq_fmt`, `set_fmt`, and `bytes_fmt` to `sequence_format_option`, `set_format_option`, and `bytes_format_option` for clarity

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a local variable rename and minor refactor of option lookups with no behavioral changes expected beyond potential KeyError surfacing if mappings are missing.
> 
> **Overview**
> Improves readability in `LiteralizerDirective.run` by renaming abbreviated local variables (`seq_fmt`, `set_fmt`, `bytes_fmt`) to clearer names (`sequence_format_option`, `set_format_option`, `bytes_format_option`).
> 
> Also slightly refactors how `sequence-format`/`bytes-format` keys are built before indexing `_SEQUENCE_FORMATS`/`_BYTES_FORMATS`, without changing directive options or output behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f8a22f67728e274489710d83b6be9bccbff1aa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->