### PR TITLE
Fix KeyError for sequence formats with single-option languages

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -305,19 +305,26 @@ _DEFAULT_SEQUENCE_FORMATS: dict[str, object] = {
 }
 
 _SEQUENCE_FORMATS: dict[tuple[str, str], object] = {
+    ("clojure", "vector"): Clojure.SequenceFormat.VECTOR,
+    ("cobol", "sequence"): Cobol.SequenceFormat.SEQUENCE,
+    ("cpp", "initializer_list"): Cpp.SequenceFormat.INITIALIZER_LIST,
     ("crystal", "array"): Crystal.SequenceFormat.ARRAY,
     ("crystal", "tuple"): Crystal.SequenceFormat.TUPLE,
     ("elixir", "list"): Elixir.SequenceFormat.LIST,
     ("elixir", "tuple"): Elixir.SequenceFormat.TUPLE,
     ("erlang", "list"): Erlang.SequenceFormat.LIST,
     ("erlang", "tuple"): Erlang.SequenceFormat.TUPLE,
+    ("go", "slice"): Go.SequenceFormat.SLICE,
     ("julia", "array"): Julia.SequenceFormat.ARRAY,
     ("julia", "tuple"): Julia.SequenceFormat.TUPLE,
+    ("lua", "table"): Lua.SequenceFormat.TABLE,
+    ("matlab", "cell_array"): Matlab.SequenceFormat.CELL_ARRAY,
     ("python", "list"): Python.SequenceFormat.LIST,
     ("python", "tuple"): Python.SequenceFormat.TUPLE,
     ("rust", "array"): Rust.SequenceFormat.ARRAY,
     ("rust", "tuple"): Rust.SequenceFormat.TUPLE,
     ("rust", "vec"): Rust.SequenceFormat.VEC,
+    ("yaml", "sequence"): Yaml.SequenceFormat.SEQUENCE,
 }
 
 _SEQUENCE_FORMAT_VALUES: tuple[str, ...] = (


### PR DESCRIPTION
The values `cell_array`, `initializer_list`, `sequence`, `slice`, `table`, and `vector` were included in `_SEQUENCE_FORMAT_VALUES` (accepted by directive validation) but had no entries in `_SEQUENCE_FORMATS`. This caused a `KeyError` at build time whenever a user explicitly specified any of these via `:sequence-format:`. Added the 7 missing `(language, format)` mappings for Clojure, Cobol, C++, Go, Lua, MATLAB, and YAML.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only expands `_SEQUENCE_FORMATS` lookup table to cover previously accepted `:sequence-format:` values, reducing build-time errors without altering core rendering logic.
> 
> **Overview**
> Fixes a build-time `KeyError` when users explicitly set `:sequence-format:` to values that were allowed by directive validation but lacked a `(language, format)` mapping.
> 
> Adds the missing `_SEQUENCE_FORMATS` entries for single-option sequence formats (e.g., `vector`, `sequence`, `initializer_list`, `slice`, `table`, `cell_array`) across Clojure, Cobol, C++, Go, Lua, MATLAB, and YAML so these options resolve correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9882020d7fea7d2f12766480822cb623434a01d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->