### PR TITLE
Validate language option with directives.choice

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -444,7 +444,10 @@ class LiteralizerDirective(SphinxDirective):
     required_arguments = 1
     has_content = False
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
-        "language": directives.unchanged_required,
+        "language": lambda x: directives.choice(
+            argument=x,
+            values=tuple(_LANGUAGE_TYPES),
+        ),
         "prefix": directives.nonnegative_int,
         "prefix-char": lambda x: directives.choice(
             argument=x,


### PR DESCRIPTION
Use `directives.choice` for the `language` directive option instead of `directives.unchanged_required`. Previously an invalid language value would pass option parsing and produce an unhelpful `KeyError` in `_default_constructor`. Now Sphinx rejects unknown languages at parse time with a clear error listing all valid values, consistent with how `date-format`, `sequence-format`, `set-format`, `bytes-format`, and `prefix-char` are already validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only directive option parsing to reject unknown `:language:` values earlier; behavior for valid languages is unchanged.
> 
> **Overview**
> Tightens validation for the `literalizer` directive’s `:language:` option by switching it from `directives.unchanged_required` to `directives.choice` using the keys of `_LANGUAGE_TYPES`.
> 
> Invalid language names now fail at Sphinx parse time with a clear “valid choices” error instead of propagating to a runtime `KeyError` during constructor selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb9ecc214f02efbdd86d99689750c2bab972bd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->