### PR TITLE
Add beartype runtime type checking to source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,13 @@ dynamic = [
     "version",
 ]
 dependencies = [
+    "beartype==0.22.9",
     "docutils",
     "literalizer==2026.3.20.2",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.11.24",
-    "beartype==0.22.9",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -10,6 +10,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, ClassVar
 
+from beartype import beartype
 from docutils import nodes
 from docutils.parsers.rst import directives
 from literalizer import Language, literalize_yaml
@@ -115,6 +116,7 @@ _LANGUAGE_TYPES: dict[str, type[Language]] = {
 }
 
 
+@beartype
 @dataclass(frozen=True)
 class _DateFormats:
     """Date and datetime format options for a language."""
@@ -354,6 +356,7 @@ _BYTES_FORMAT_VALUES: tuple[str, ...] = (
 )
 
 
+@beartype
 def _apply_date_formats(
     constructor: partial[Language],
     date_formats: _DateFormats,
@@ -372,6 +375,7 @@ def _apply_date_formats(
     return constructor
 
 
+@beartype
 def _default_constructor(
     language_name: str,
 ) -> partial[Language]:
@@ -423,6 +427,7 @@ def _default_constructor(
     return constructor
 
 
+@beartype
 class LiteralizerDirective(SphinxDirective):
     """Directive that converts a JSON file to a native literal block.
 
@@ -559,6 +564,7 @@ class LiteralizerDirective(SphinxDirective):
         return [node]
 
 
+@beartype
 def setup(app: Sphinx) -> ExtensionMetadata:
     """Register the extension with Sphinx."""
     app.add_directive(name="literalizer", cls=LiteralizerDirective)

--- a/uv.lock
+++ b/uv.lock
@@ -1493,6 +1493,7 @@ wheels = [
 name = "sphinx-literalizer"
 source = { editable = "." }
 dependencies = [
+    { name = "beartype" },
     { name = "docutils" },
     { name = "literalizer" },
     { name = "sphinx" },
@@ -1501,7 +1502,6 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "actionlint-py" },
-    { name = "beartype" },
     { name = "check-manifest" },
     { name = "deptry" },
     { name = "doc8" },
@@ -1540,7 +1540,7 @@ release = [
 [package.metadata]
 requires-dist = [
     { name = "actionlint-py", marker = "extra == 'dev'", specifier = "==1.7.11.24" },
-    { name = "beartype", marker = "extra == 'dev'", specifier = "==0.22.9" },
+    { name = "beartype", specifier = "==0.22.9" },
     { name = "check-manifest", marker = "extra == 'dev'", specifier = "==0.51" },
     { name = "check-wheel-contents", marker = "extra == 'release'", specifier = "==0.6.3" },
     { name = "deptry", marker = "extra == 'dev'", specifier = "==0.25.1" },


### PR DESCRIPTION
## Summary

- Add `@beartype` decorator to all functions and classes in `src/sphinx_literalizer/__init__.py` for runtime type checking
- Move `beartype` from dev dependency to runtime dependency since it's now used in source code

## Test plan

- [x] Pre-commit hooks pass (mypy, pyright, ruff, deptry, etc.)
- [x] `uv run python -c "import sphinx_literalizer"` succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces runtime type enforcement in directive/construction code, which can raise new exceptions in previously-tolerated edge cases and adds a new required dependency at import time.
> 
> **Overview**
> Adds `beartype` runtime type checking to `src/sphinx_literalizer/__init__.py` by importing `beartype` and decorating key helpers (e.g. `_apply_date_formats`, `_default_constructor`), the `_DateFormats` dataclass, `LiteralizerDirective`, and `setup`.
> 
> Moves `beartype==0.22.9` from the `dev` extra into core `dependencies` (and updates `uv.lock`) so the extension can import and use `beartype` at runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6496b742b2577df03a35a71a60cde71b0900406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->