### PR TITLE
Bump literalizer to 2026.3.30 and add new format options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.3.30``.
+- Added ``:dict-entry-style:`` directive option.
+- Added ``:float-format:`` directive option.
+- Added ``:numeric-literal-suffix:`` directive option.
+- Added ``:default-ordered-map-value-type:`` directive option.
+
 2026.03.26.2
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.3.29",
+    "literalizer==2026.3.30",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -47,8 +47,11 @@ _FORMAT_OPTION_GETTERS: dict[
     "comment-format": lambda cls: cls.CommentFormats,
     "variable-type-hints": lambda cls: cls.VariableTypeHints,
     "declaration-style": lambda cls: cls.DeclarationStyles,
+    "dict-entry-style": lambda cls: cls.DictEntryStyles,
     "dict-format": lambda cls: cls.DictFormats,
+    "float-format": lambda cls: cls.FloatFormats,
     "integer-format": lambda cls: cls.IntegerFormats,
+    "numeric-literal-suffix": lambda cls: cls.NumericLiteralSuffixes,
     "numeric-separator": lambda cls: cls.NumericSeparators,
     "string-format": lambda cls: cls.StringFormats,
     "trailing-comma": lambda cls: cls.TrailingCommas,
@@ -134,8 +137,11 @@ class LiteralizerDirective(SphinxDirective):
            :comment-format: block
            :variable-type-hints: always
            :declaration-style: const
+           :dict-entry-style: rocket
            :dict-format: object
+           :float-format: repr
            :integer-format: decimal
+           :numeric-literal-suffix: none
            :numeric-separator: none
            :string-format: double
            :trailing-comma: yes
@@ -145,6 +151,7 @@ class LiteralizerDirective(SphinxDirective):
            :default-sequence-element-type: String
            :default-dict-key-type: String
            :default-dict-value-type: String
+           :default-ordered-map-value-type: any
     """
 
     required_arguments = 1
@@ -171,6 +178,7 @@ class LiteralizerDirective(SphinxDirective):
         "default-sequence-element-type": directives.unchanged,
         "default-dict-key-type": directives.unchanged,
         "default-dict-value-type": directives.unchanged,
+        "default-ordered-map-value-type": directives.unchanged,
     }
 
     def _apply_format_options(
@@ -222,6 +230,10 @@ class LiteralizerDirective(SphinxDirective):
             "default-dict-value-type": (
                 "default_dict_value_type",
                 lambda cls: cls.supports_default_dict_value_type,
+            ),
+            "default-ordered-map-value-type": (
+                "default_ordered_map_value_type",
+                lambda cls: cls.supports_default_ordered_map_value_type,
             ),
         }
         language_cls = _language_types()[language_name]

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -2852,7 +2852,7 @@ def test_unsupported_default_set_element_type_error(
         ====
 
         .. literalizer:: data.json
-           :language: python
+           :language: javascript
            :default-set-element-type: Int
     """
         )
@@ -2864,7 +2864,7 @@ def test_unsupported_default_set_element_type_error(
     )
     with pytest.raises(
         expected_exception=ExtensionError,
-        match=r"Language 'python' does not support 'default-set-element-type'\.",
+        match=r"Language 'javascript' does not support 'default-set-element-type'\.",
     ):
         app.build()
 
@@ -2965,6 +2965,296 @@ def test_default_dict_key_type(
     app.build()
     assert app.statuscode == 0
     app.cleanup()
+
+
+def test_dict_entry_style_symbol(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :dict-entry-style: option changes how dict entries are rendered."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"key": "value"}),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: ruby
+           :dict-entry-style: symbol
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    app.cleanup()
+
+
+def test_float_format_scientific(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :float-format: option changes how floats are rendered."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1234.5]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :float-format: scientific
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    app.cleanup()
+
+
+def test_float_format_fixed(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :float-format: fixed option renders floats in fixed
+    notation.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1234.5]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :float-format: fixed
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    app.cleanup()
+
+
+def test_numeric_literal_suffix_auto(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :numeric-literal-suffix: option adds type suffixes to
+    numbers.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[42]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: go
+           :numeric-literal-suffix: auto
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    app.cleanup()
+
+
+def test_unsupported_dict_entry_style_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """An unsupported dict-entry-style raises a clear ExtensionError."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :dict-entry-style: symbol
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=r"Language 'python' does not support dict-entry-style 'symbol'\.",
+    ):
+        app.build()
+
+
+def test_unsupported_numeric_literal_suffix_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """An unsupported numeric-literal-suffix raises a clear
+    ExtensionError.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[42]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :numeric-literal-suffix: auto
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=r"Language 'python' does not support numeric-literal-suffix 'auto'\.",
+    ):
+        app.build()
+
+
+def test_default_ordered_map_value_type(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :default-ordered-map-value-type: option works for Go."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: go
+           :default-ordered-map-value-type: any
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    app.cleanup()
+
+
+def test_unsupported_default_ordered_map_value_type_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :default-ordered-map-value-type: option is rejected for
+    unsupported languages.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :default-ordered-map-value-type: Any
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=r"Language 'python' does not support 'default-ordered-map-value-type'\.",
+    ):
+        app.build()
 
 
 def test_default_dict_value_type(

--- a/uv.lock
+++ b/uv.lock
@@ -623,15 +623,15 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.3.29"
+version = "2026.3.30"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/2c/a67c7ae4d27755863ff4de6dd910c08858ca548fa9db48fd5218efb7c077/literalizer-2026.3.29.tar.gz", hash = "sha256:292d86ba4d7e3cd2e35de464e8b120d9f2c54bed73b1de1f86c8b642fed6ed87", size = 616704, upload-time = "2026-03-29T07:39:23.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/fd/a20a33e076b0013d64b8e2c583ab009e23464eff5a48aaf0bac05129b93a/literalizer-2026.3.30.tar.gz", hash = "sha256:2b2ab69d3d57cb9fcf07bd8412e90f4a4f85bf66b5f05456ddaaed08a7c0b8b5", size = 663851, upload-time = "2026-03-30T11:02:57.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/47/67a3505f194fa9e7fc0e74c16d5eaca1b2fa9c911d94cd6617214204fb2b/literalizer-2026.3.29-py3-none-any.whl", hash = "sha256:7c5f893988e042d4c93e67f126bae76cdc8f78ea92db120d8c91f540b7012615", size = 187083, upload-time = "2026-03-29T07:39:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/0c3391d6395d8d490bc764c89c5f527d306c9c6c2f53f33c2b23e3fedb4b/literalizer-2026.3.30-py3-none-any.whl", hash = "sha256:b89563bd10700865a3ce22c7639bbc48ec52934b4b28c679d0bfe6322a1a601a", size = 204629, upload-time = "2026-03-30T11:02:55.461Z" },
 ]
 
 [[package]]
@@ -1594,7 +1594,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.3.29" },
+    { name = "literalizer", specifier = "==2026.3.30" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.8" },


### PR DESCRIPTION
Bumps `literalizer` to `2026.3.30` and exposes four new directive options from the upstream release: `:dict-entry-style:` (e.g. Ruby's rocket vs symbol), `:float-format:` (repr/scientific/fixed), `:numeric-literal-suffix:` (none/auto for C/C++/Go/Java), and `:default-ordered-map-value-type:` (supported by Go). Includes tests for each new option and corresponding unsupported-language error paths, and updates an existing test that broke because Python now supports default type options upstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes directive option parsing and rendered output behavior by upgrading the core `literalizer` dependency and adding new formatting/type knobs; regressions would surface in generated docs across languages.
> 
> **Overview**
> Bumps `literalizer` to `2026.3.30` (updating `pyproject.toml`/`uv.lock`) and documents the change in `CHANGELOG.rst`.
> 
> Extends the `literalizer` Sphinx directive to accept and validate four new upstream options—`dict-entry-style`, `float-format`, `numeric-literal-suffix`, and `default-ordered-map-value-type`—and wires them into language construction alongside existing format/default-type options.
> 
> Adds integration tests covering the new options and their unsupported-language error messages, and updates an existing default-type rejection test to use a language that remains unsupported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1634f74b8f27b3e84a6f603e9932918f33b09423. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->