### PR TITLE
Add literalizer-call directive

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -416,6 +416,73 @@ renders as a code block containing:
    ]
 
 
+``literalizer-call`` directive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``literalizer-call`` directive converts data files into function call
+expressions.  Each top-level list element becomes a separate call (when
+``:per-element:`` is set), with its values mapped positionally to the
+given parameter names.
+
+.. code-block:: rst
+
+   .. literalizer-call:: calls.json
+      :language: python
+      :call-function: my_func
+      :call-params: flag,count,name
+      :per-element:
+
+Given a file ``calls.json`` containing:
+
+.. code-block:: json
+
+   [[true, 42, "hello"], [false, 99, "world"]]
+
+This renders as a code block containing::
+
+   my_func(flag=True, count=42, name="hello")
+   my_func(flag=False, count=99, name="world")
+
+For positional-call languages like Go, the same data renders as:
+
+.. code-block:: rst
+
+   .. literalizer-call:: calls.json
+      :language: go
+      :call-function: myFunc
+      :call-params: flag,count
+      :per-element:
+
+.. code-block:: go
+
+   myFunc(true, 42);
+   myFunc(false, 99);
+
+``literalizer-call`` directive options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``:call-function:`` (required)
+   The function expression to call (e.g. ``my_func`` or
+   ``throttler.should_send_notification``).
+
+``:call-params:`` (required)
+   Comma-separated parameter names, positionally mapped to each
+   element in each row.  For positional-call languages (like Go) these
+   are unused in the output but still determine how many values to
+   expect per row.
+
+``:per-element:`` (optional flag)
+   When set, each top-level list element becomes a separate function
+   call.  Without this flag, the whole literalized value is passed as a
+   single argument.
+
+The ``literalizer-call`` directive also supports these shared options
+from the ``literalizer`` directive: ``:language:``, ``:input-format:``,
+``:pre-indent-level:``, ``:indent:``, ``:indent-char:``,
+``:include-preamble:``, and all format options (e.g. ``:string-format:``,
+``:trailing-comma:``, etc.).
+
+
 Reference
 ---------
 

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -436,6 +436,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             language_cls=language_cls,
         )
 
+        pre_indent_level: int = self.options.get("pre-indent-level", 0)
         include_preamble: bool = "include-preamble" in self.options
         call_function: str = self.options["call-function"]
         call_params = [
@@ -452,10 +453,18 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             call_params=call_params,
             per_element=per_element,
         )
+
+        code = result.code
+        if pre_indent_level > 0:
+            indent = language_spec.indent * pre_indent_level
+            code = "\n".join(
+                indent + line if line else line for line in code.splitlines()
+            )
+
         parts: list[str] = []
         if include_preamble and result.preamble:
             parts.append("\n".join(result.preamble))
-        parts.append(result.code)
+        parts.append(code)
         text = "\n\n".join(parts)
 
         return self._make_node(

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -1,7 +1,7 @@
 """Sphinx extension for literalizer.
 
-Provides the ``literalizer`` directive, which reads a data file and
-renders it as a native language literal block.
+Provides the ``literalizer`` and ``literalizer-call`` directives, which
+read data files and render them as native language code blocks.
 """
 
 import enum
@@ -13,7 +13,13 @@ from typing import Any, ClassVar
 from beartype import beartype
 from docutils import nodes
 from docutils.parsers.rst import directives
-from literalizer import InputFormat, Language, LanguageCls, literalize
+from literalizer import (
+    InputFormat,
+    Language,
+    LanguageCls,
+    literalize,
+    literalize_call,
+)
 from literalizer.languages import ALL_LANGUAGES
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
@@ -115,78 +121,48 @@ def _make_format_validator(
     return validator
 
 
+_COMMON_OPTIONS: dict[str, Callable[[str], Any]] = {
+    "language": lambda x: directives.choice(
+        argument=x,
+        values=tuple(_language_types()),
+    ),
+    "input-format": lambda x: directives.choice(
+        argument=x,
+        values=("json", "json5", "yaml", "toml"),
+    ),
+    "pre-indent-level": directives.nonnegative_int,
+    "indent": directives.nonnegative_int,
+    "indent-char": lambda x: directives.choice(
+        argument=x,
+        values=("spaces", "tabs"),
+    ),
+    "include-preamble": directives.flag,
+    **{
+        option_name: _make_format_validator(option_name=option_name)
+        for option_name in _FORMAT_OPTION_GETTERS
+    },
+    "default-set-element-type": directives.unchanged,
+    "default-sequence-element-type": directives.unchanged,
+    "default-dict-key-type": directives.unchanged,
+    "default-dict-value-type": directives.unchanged,
+    "default-ordered-map-value-type": directives.unchanged,
+}
+
+_EXTENSION_TO_INPUT_FORMAT: dict[str, InputFormat] = {
+    ".json": InputFormat.JSON,
+    ".json5": InputFormat.JSON5,
+    ".yaml": InputFormat.YAML,
+    ".yml": InputFormat.YAML,
+    ".toml": InputFormat.TOML,
+}
+
+
 @beartype
-class LiteralizerDirective(SphinxDirective):
-    """Directive that converts a data file to a native literal block.
-
-    Usage::
-
-        .. literalizer:: path/to/data.json
-           :language: python
-           :input-format: json
-           :pre-indent-level: 2
-           :indent: 4
-           :indent-char: spaces
-           :include-delimiters:
-           :include-preamble:
-           :date-format: python
-           :datetime-format: python
-           :variable-name: my_var
-           :existing-variable:
-           :sequence-format: list
-           :set-format: frozenset
-           :bytes-format: python
-           :comment-format: block
-           :variable-type-hints: always
-           :declaration-style: const
-           :dict-entry-style: rocket
-           :dict-format: object
-           :float-format: repr
-           :integer-format: decimal
-           :numeric-literal-suffix: none
-           :numeric-separator: none
-           :string-format: double
-           :trailing-comma: yes
-           :line-ending: semicolon
-           :empty-dict-key: positional
-           :default-set-element-type: String
-           :default-sequence-element-type: String
-           :default-dict-key-type: String
-           :default-dict-value-type: String
-           :default-ordered-map-value-type: any
-    """
+class _BaseLiteralizerDirective(SphinxDirective):
+    """Shared logic for literalizer directives."""
 
     required_arguments = 1
     has_content = False
-    option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
-        "language": lambda x: directives.choice(
-            argument=x,
-            values=tuple(_language_types()),
-        ),
-        "input-format": lambda x: directives.choice(
-            argument=x,
-            values=("json", "json5", "yaml", "toml"),
-        ),
-        "pre-indent-level": directives.nonnegative_int,
-        "indent": directives.nonnegative_int,
-        "indent-char": lambda x: directives.choice(
-            argument=x,
-            values=("spaces", "tabs"),
-        ),
-        "include-delimiters": directives.flag,
-        "include-preamble": directives.flag,
-        **{
-            option_name: _make_format_validator(option_name=option_name)
-            for option_name in _FORMAT_OPTION_GETTERS
-        },
-        "variable-name": directives.unchanged,
-        "existing-variable": directives.flag,
-        "default-set-element-type": directives.unchanged,
-        "default-sequence-element-type": directives.unchanged,
-        "default-dict-key-type": directives.unchanged,
-        "default-dict-value-type": directives.unchanged,
-        "default-ordered-map-value-type": directives.unchanged,
-    }
 
     def _apply_format_options(
         self,
@@ -290,14 +266,6 @@ class LiteralizerDirective(SphinxDirective):
         )
         return constructor()
 
-    _EXTENSION_TO_INPUT_FORMAT: ClassVar[dict[str, InputFormat]] = {
-        ".json": InputFormat.JSON,
-        ".json5": InputFormat.JSON5,
-        ".yaml": InputFormat.YAML,
-        ".yml": InputFormat.YAML,
-        ".toml": InputFormat.TOML,
-    }
-
     def _resolve_input_format(self, data_path: Path) -> InputFormat:
         """Determine the input format from the option or file
         extension.
@@ -307,13 +275,78 @@ class LiteralizerDirective(SphinxDirective):
             return InputFormat[explicit.upper()]
         suffix = data_path.suffix.lower()
         try:
-            return self._EXTENSION_TO_INPUT_FORMAT[suffix]
+            return _EXTENSION_TO_INPUT_FORMAT[suffix]
         except KeyError:
             msg = (
                 f"Cannot determine input format for '{data_path.name}'. "
                 f"Use the :input-format: option."
             )
             raise ExtensionError(message=msg) from None
+
+    def _make_node(
+        self,
+        text: str,
+        data_path: Path,
+        language_cls: LanguageCls,
+    ) -> list[nodes.Node]:
+        """Create a literal_block node."""
+        node = nodes.literal_block(
+            text,
+            text,
+            source=str(object=data_path),
+        )
+        node["language"] = language_cls.pygments_name or "text"
+        self.add_name(node=node)
+        return [node]
+
+
+@beartype
+class LiteralizerDirective(_BaseLiteralizerDirective):
+    """Directive that converts a data file to a native literal block.
+
+    Usage::
+
+        .. literalizer:: path/to/data.json
+           :language: python
+           :input-format: json
+           :pre-indent-level: 2
+           :indent: 4
+           :indent-char: spaces
+           :include-delimiters:
+           :include-preamble:
+           :date-format: python
+           :datetime-format: python
+           :variable-name: my_var
+           :existing-variable:
+           :sequence-format: list
+           :set-format: frozenset
+           :bytes-format: python
+           :comment-format: block
+           :variable-type-hints: always
+           :declaration-style: const
+           :dict-entry-style: rocket
+           :dict-format: object
+           :float-format: repr
+           :integer-format: decimal
+           :numeric-literal-suffix: none
+           :numeric-separator: none
+           :string-format: double
+           :trailing-comma: yes
+           :line-ending: semicolon
+           :empty-dict-key: positional
+           :default-set-element-type: String
+           :default-sequence-element-type: String
+           :default-dict-key-type: String
+           :default-dict-value-type: String
+           :default-ordered-map-value-type: any
+    """
+
+    option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
+        **_COMMON_OPTIONS,
+        "include-delimiters": directives.flag,
+        "variable-name": directives.unchanged,
+        "existing-variable": directives.flag,
+    }
 
     def run(self) -> list[nodes.Node]:
         """Read the data file and produce a literal block."""
@@ -358,20 +391,88 @@ class LiteralizerDirective(SphinxDirective):
         # Sphinx's built-in LiteralInclude directive, which also stores an
         # absolute path so that downstream code can rely on it without having
         # to resolve relative→absolute itself.
-        node = nodes.literal_block(
-            text,
-            text,
-            source=str(object=data_path),
+        return self._make_node(
+            text=text,
+            data_path=data_path,
+            language_cls=language_cls,
         )
-        node["language"] = language_cls.pygments_name or "text"
-        self.add_name(node=node)
-        return [node]
+
+
+@beartype
+class LiteralizerCallDirective(_BaseLiteralizerDirective):
+    """Directive that converts a data file to function call expressions.
+
+    Usage::
+
+        .. literalizer-call:: path/to/data.json
+           :language: python
+           :call-function: my_func
+           :call-params: flag,count,name
+           :per-element:
+           :input-format: json
+           :indent: 4
+           :indent-char: spaces
+           :include-preamble:
+    """
+
+    option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
+        **_COMMON_OPTIONS,
+        "call-function": directives.unchanged_required,
+        "call-params": directives.unchanged_required,
+        "per-element": directives.flag,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        """Read the data file and produce function call expressions."""
+        env = self.state.document.settings.env
+        data_path = (Path(env.srcdir) / self.arguments[0]).resolve()
+
+        env.note_dependency(str(object=data_path))
+
+        language_name: str = self.options["language"]
+        language_cls = _language_types()[language_name]
+        language_spec = self._build_language(
+            language_name=language_name,
+            language_cls=language_cls,
+        )
+
+        include_preamble: bool = "include-preamble" in self.options
+        call_function: str = self.options["call-function"]
+        call_params = [
+            p.strip() for p in self.options["call-params"].split(",")
+        ]
+        per_element: bool = "per-element" in self.options
+
+        input_format = self._resolve_input_format(data_path=data_path)
+        result = literalize_call(
+            source=data_path.read_text(encoding="utf-8"),
+            input_format=input_format,
+            language=language_spec,
+            call_function=call_function,
+            call_params=call_params,
+            per_element=per_element,
+        )
+        parts: list[str] = []
+        if include_preamble and result.preamble:
+            parts.append("\n".join(result.preamble))
+        parts.append(result.code)
+        text = "\n\n".join(parts)
+
+        return self._make_node(
+            text=text,
+            data_path=data_path,
+            language_cls=language_cls,
+        )
 
 
 @beartype
 def setup(app: Sphinx) -> ExtensionMetadata:
     """Register the extension with Sphinx."""
     app.add_directive(name="literalizer", cls=LiteralizerDirective)
+    app.add_directive(
+        name="literalizer-call",
+        cls=LiteralizerCallDirective,
+    )
     return {
         "version": "0.1.0",
         "parallel_read_safe": True,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3614,3 +3614,247 @@ def test_no_include_preamble_by_default(
     assert not text.startswith("package main")
     assert "x := map[string]string{" in text
     app.cleanup()
+
+
+def test_literalizer_call_basic_python(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The literalizer-call directive renders function calls matching
+    an equivalent code-block.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42, "hello"], [False, 99, "world"]]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :call-function: my_func
+           :call-params: flag,count,name
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           my_func(flag=True, count=42, name="hello")
+           my_func(flag=False, count=99, name="world")
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_literalizer_call_go(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The literalizer-call directive renders positional-style calls
+    for Go.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42], [False, 99]]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: go
+           :call-function: myFunc
+           :call-params: flag,count
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    literal_blocks = list(
+        doctree.findall(condition=nodes.literal_block),
+    )
+    (literal_block,) = literal_blocks
+    text = literal_block.astext()
+    assert "myFunc(true, 42)" in text
+    assert "myFunc(false, 99)" in text
+    app.cleanup()
+
+
+def test_literalizer_call_without_per_element(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Without :per-element:, the whole value is passed as a single
+    argument.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, 2, 3]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :call-function: my_func
+           :call-params: x
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    literal_blocks = list(
+        doctree.findall(condition=nodes.literal_block),
+    )
+    (literal_block,) = literal_blocks
+    text = literal_block.astext()
+    assert "my_func" in text
+    app.cleanup()
+
+
+def test_literalizer_call_include_preamble(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :include-preamble: option works with literalizer-call."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42]]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: go
+           :call-function: myFunc
+           :call-params: flag,count
+           :per-element:
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    literal_blocks = list(
+        doctree.findall(condition=nodes.literal_block),
+    )
+    (literal_block,) = literal_blocks
+    text = literal_block.astext()
+    assert "package main" in text
+    assert "myFunc(true, 42)" in text
+    app.cleanup()
+
+
+def test_literalizer_call_source_is_absolute(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The literal_block node's source attribute is an absolute path."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :call-function: f
+           :call-params: x
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    literal_blocks = list(doctree.findall(condition=nodes.literal_block))
+    (literal_block,) = literal_blocks
+    source = literal_block["source"]
+    assert Path(source).is_absolute()
+    app.cleanup()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -55,6 +55,49 @@ def test_source_attribute_is_absolute(
     app.cleanup()
 
 
+def test_literalizer_call_pre_indent_level(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :pre-indent-level: option indents the generated calls."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :call-function: f
+           :call-params: flag,count
+           :per-element:
+           :pre-indent-level: 2
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    literal_blocks = list(doctree.findall(condition=nodes.literal_block))
+    (literal_block,) = literal_blocks
+    text = literal_block.astext()
+    assert text.startswith("        f(")
+    app.cleanup()
+
+
 def test_boolean_array_python(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
## Summary
- Adds a new `literalizer-call` Sphinx directive that wraps `literalize_call` from the `literalizer` library, converting data files into function call expressions
- Extracts shared logic between `LiteralizerDirective` and `LiteralizerCallDirective` into a `_BaseLiteralizerDirective` base class to reduce duplication
- Adds documentation for the new directive with Python and Go examples
- Adds 5 tests covering basic Python calls, Go positional calls, per-element behavior, preamble support, and source path handling

## Test plan
- [x] All 79 tests pass (74 existing + 5 new)
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new directive and refactors shared option parsing/node creation used by the existing `literalizer` directive, which could affect rendering or option handling despite added coverage.
> 
> **Overview**
> Adds a new `literalizer-call` directive that wraps `literalize_call` to turn structured data files into language-specific function call code blocks, supporting `:call-function:`, `:call-params:`, and optional `:per-element:`.
> 
> Refactors the extension by extracting shared option specs and helper methods into `_BaseLiteralizerDirective` (including input-format resolution and literal block node creation), and registers the new directive in `setup()`.
> 
> Updates the docs with Python/Go examples and adds integration tests covering call rendering, `:per-element:` behavior, pre-indentation, preamble inclusion, and absolute `source` paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228776d20020a64e3dc6f887db176b23f5dbc488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->