### PR TITLE
Expose call-transform option on literalizer-call directive

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -409,6 +409,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :target-function: my_func
            :parameter-names: flag,count,name
            :per-element:
+           :call-transform: print($0)
            :input-format: json
            :indent: 4
            :indent-char: spaces
@@ -420,6 +421,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         "target-function": directives.unchanged_required,
         "parameter-names": directives.unchanged_required,
         "per-element": directives.flag,
+        "call-transform": directives.unchanged_required,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -444,6 +446,19 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         ]
         per_element: bool = "per-element" in self.options
 
+        call_transform_template: str | None = self.options.get(
+            "call-transform",
+        )
+        call_transform: Callable[[str], str] | None = None
+        if call_transform_template is not None:
+            template = call_transform_template
+
+            def _call_transform(call_str: str) -> str:
+                """Replace ``$0`` with the call expression."""
+                return template.replace("$0", call_str)
+
+            call_transform = _call_transform
+
         input_format = self._resolve_input_format(data_path=data_path)
         result = literalize_call(
             source=data_path.read_text(encoding="utf-8"),
@@ -451,6 +466,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             language=language_spec,
             target_function=target_function,
             parameter_names=parameter_names,
+            call_transform=call_transform,
             per_element=per_element,
         )
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3901,3 +3901,65 @@ def test_literalizer_call_source_is_absolute(
     source = literal_block["source"]
     assert Path(source).is_absolute()
     app.cleanup()
+
+
+def test_literalizer_call_call_transform(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The literalizer-call directive supports :call-transform: to wrap
+    each call expression.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42, "hello"], [False, 99, "world"]]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: my_func
+           :parameter-names: flag,count,name
+           :per-element:
+           :call-transform: print($0)
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           print(my_func(flag=True, count=42, name="hello"))
+           print(my_func(flag=False, count=99, name="world"))
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html


### PR DESCRIPTION
## Summary
- Adds `:call-transform:` option to the `literalizer-call` directive, exposing the `call_transform` parameter from `literalize_call`
- Uses `$0` as a placeholder for the call expression (e.g., `print($0)` wraps each call in `print(...)`)
- Includes test verifying the option produces correct output

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional directive option that wraps generated call strings and is covered by an integration test; no changes to parsing, I/O, or security-sensitive logic.
> 
> **Overview**
> Adds a new `:call-transform:` option to the `literalizer-call` Sphinx directive, allowing each generated call expression to be wrapped via a template where `$0` is replaced with the call (e.g., `print($0)`).
> 
> Includes an integration test asserting the transformed output matches an equivalent `code-block` rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e142a0ae7fc8d111cb75dcd7870ecabb9361734e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->