### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,13 +1,3 @@
 """Pytest configuration."""
 
-import pytest
-from beartype import beartype
-
 pytest_plugins = "sphinx.testing.fixtures"
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests==2026.4.19.1",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     "shellcheck-py==0.11.0.1",
@@ -222,7 +223,6 @@ linewrap-full-docstring = true
 [tool.vulture]
 ignore_names = [
     # pytest configuration
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",
@@ -265,3 +265,6 @@ exclude = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[dependency-groups]
+dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ optional-dependencies.release = [
 urls.Documentation = "https://adamtheturtle.github.io/sphinx-literalizer/"
 urls.Source = "https://github.com/adamtheturtle/sphinx-literalizer"
 
+[dependency-groups]
+dev = []
+
 [tool.setuptools]
 zip-safe = false
 package-data.sphinx_literalizer = [
@@ -265,6 +268,3 @@ exclude = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []

--- a/uv.lock
+++ b/uv.lock
@@ -1260,6 +1260,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-beartype-tests"
+version = "2026.4.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/85/2a4abab012ea412757aee0c77a63759c9df997456ae75dc0a590071bf11d/pytest_beartype_tests-2026.4.19.1.tar.gz", hash = "sha256:02662a7c189666eac26d5994d8d750106c73b0cd31ed0d01222db59ba1cb6e5a", size = 85947, upload-time = "2026-04-19T07:56:18.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/c0/8c57af81595948ddab76b78635931ed5adac38fc46565e8419dc3a5046b3/pytest_beartype_tests-2026.4.19.1-py3-none-any.whl", hash = "sha256:20618dd92dc2c8e1cab94f5984a382c95d03376ef94558e54665908e56ad8cc4", size = 5198, upload-time = "2026-04-19T07:56:16.711Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1663,6 +1676,7 @@ dev = [
     { name = "pyright" },
     { name = "pyroma" },
     { name = "pytest" },
+    { name = "pytest-beartype-tests" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "shellcheck-py" },
@@ -1706,6 +1720,7 @@ requires-dist = [
     { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.408" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
+    { name = "pytest-beartype-tests", marker = "extra == 'dev'", specifier = "==2026.4.19.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.11" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
@@ -1724,6 +1739,9 @@ requires-dist = [
     { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.24.1" },
 ]
 provides-extras = ["dev", "release"]
+
+[package.metadata.requires-dev]
+dev = []
 
 [[package]]
 name = "sphinx-pyproject"


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes test-time type enforcement wiring and dev dependencies, with no runtime/library behavior changes. Main risk is slight differences in the plugin’s collection/decorator behavior affecting test execution.
> 
> **Overview**
> **Test configuration cleanup:** removes the custom `pytest_collection_modifyitems` hook in `conftest.py` that wrapped collected tests with `beartype`, relying on plugin-based behavior instead.
> 
> **Dev tooling updates:** adds `pytest-beartype-tests` to `pyproject.toml` dev dependencies, updates `uv.lock` accordingly, and drops the now-unused `vulture` ignore for `pytest_collection_modifyitems` (plus a small `[dependency-groups]` metadata entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6314a1650cbb9f3afe0b0710ad299ac894f454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->