### PR TITLE
Bump literalizer to 2026.4.21.3 and add :heterogeneous-strategy: option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+2026.04.21.3
+------------
+
+- Bumped ``literalizer`` to ``2026.4.21.3``.
+- Added ``:heterogeneous-strategy:`` directive option, exposing
+  language-level heterogeneous-scalar strategies such as Rust's
+  ``tagged_enum``.
+
 2026.04.21
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -408,6 +408,18 @@ Directive options
    ``error``
       Raise an error on empty keys.  Available for R.
 
+``:heterogeneous-strategy:`` (optional)
+   How to render scalar collections whose elements have more than one
+   language-level type.  Supported values:
+
+   ``error``
+      Raise an error when a collection mixes scalar types (default for
+      all languages).
+   ``tagged_enum``
+      Emit a minimal tagged ``enum`` in the preamble and wrap each
+      heterogeneous value at the call site (e.g. ``Value::I32(1)``).
+      Available for Rust.
+
 Example
 ~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.21.1",
+    "literalizer==2026.4.21.3",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -66,6 +66,7 @@ _FORMAT_OPTION_GETTERS: dict[
     "trailing-comma": lambda cls: cls.TrailingCommas,
     "line-ending": lambda cls: cls.LineEndings,
     "empty-dict-key": lambda cls: cls.EmptyDictKey,
+    "heterogeneous-strategy": lambda cls: cls.HeterogeneousStrategies,
 }
 
 
@@ -358,6 +359,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :trailing-comma: yes
            :line-ending: semicolon
            :empty-dict-key: positional
+           :heterogeneous-strategy: tagged_enum
            :default-set-element-type: String
            :default-sequence-element-type: String
            :default-dict-key-type: String

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3090,6 +3090,89 @@ def test_empty_dict_key_positional(
     app.cleanup()
 
 
+def test_heterogeneous_strategy_unsupported_value(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :heterogeneous-strategy: option rejects values a language
+    does not support.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :heterogeneous-strategy: tagged_enum
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"Language 'python' does not support "
+            r"heterogeneous-strategy 'tagged_enum'\."
+        ),
+    ):
+        app.build()
+
+
+def test_heterogeneous_strategy_tagged_enum(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Rust's :heterogeneous-strategy: tagged_enum renders mixed scalars
+    via a generated tagged enum.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, "hello"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: tagged_enum
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "enum Value {" in text
+    assert "Value::I32(1)" in text
+    assert 'Value::Str("hello")' in text
+    app.cleanup()
+
+
 def test_unsupported_default_set_element_type_error(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3152,6 +3152,7 @@ def test_heterogeneous_strategy_tagged_enum(
         .. literalizer:: data.json
            :language: rust
            :heterogeneous-strategy: tagged_enum
+           :include-delimiters:
            :include-preamble:
     """
         )
@@ -3166,10 +3167,19 @@ def test_heterogeneous_strategy_tagged_enum(
 
     doctree = app.env.get_doctree(docname="index")
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
-    text = literal_block.astext()
-    assert "enum Value {" in text
-    assert "Value::I32(1)" in text
-    assert 'Value::Str("hello")' in text
+    expected = dedent(
+        text="""\
+        enum Value {
+            I32(i32),
+            Str(&'static str),
+        }
+
+        vec![
+            Value::I32(1),
+            Value::Str("hello"),
+        ]"""
+    )
+    assert literal_block.astext() == expected
     app.cleanup()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -623,7 +623,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.21.1"
+version = "2026.4.21.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -631,9 +631,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/99/e8364ae2a5b4492a3fa2bfa5a37ce6dc2b8f124ccfd2f13537584191a867/literalizer-2026.4.21.1.tar.gz", hash = "sha256:41e4aa430fb79b86fc1cc0a5e9c26d6370c4186674ed73d1d1ca152306e497a6", size = 1118597, upload-time = "2026-04-21T05:46:35.483Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c6/7e770165b77120e2c748c6a523f0003fe5051f2eb15f40da293f29a5c596/literalizer-2026.4.21.3.tar.gz", hash = "sha256:73236037dde509aae4b0f70a8e02370b1ee6c3ef3f37c6bf7f0a30ae3551a45f", size = 1136182, upload-time = "2026-04-21T09:51:17.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/d8/38ec6b5529e740d41dd9cd749d000de8cc5441d9f5abd640b820cd147815/literalizer-2026.4.21.1-py3-none-any.whl", hash = "sha256:ec7754e51e907ecc9aef6dbabdedc40fc8d8363118a1c4263bb978bf169f755a", size = 369164, upload-time = "2026-04-21T05:46:33.722Z" },
+    { url = "https://files.pythonhosted.org/packages/06/34/aacaad872b74e45d1b6fdd040a85b19dd97b45f091fea7611c4b9bf841e3/literalizer-2026.4.21.3-py3-none-any.whl", hash = "sha256:5276c82d064f80715b064e4ec2ff2c877b5c4bfd8cd704a8dcfb95d2a9fb9b62", size = 385886, upload-time = "2026-04-21T09:51:15.283Z" },
 ]
 
 [[package]]
@@ -1709,7 +1709,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.21.1" },
+    { name = "literalizer", specifier = "==2026.4.21.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.9" },


### PR DESCRIPTION
## Summary
- Bumped ``literalizer`` to ``2026.4.21.3``.
- Added ``:heterogeneous-strategy:`` directive option, exposing the new language-level ``HeterogeneousStrategies`` enum (Rust's ``tagged_enum`` strategy, alongside the default ``error``).

## Test plan
- [x] ``uv run pytest tests/test_extension.py``
- [x] ``uv run ruff check`` and ``uv run mypy``
- [x] ``uv run sphinx-build -b html docs/source docs/build/html -W``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps a core rendering dependency and introduces a new rendering strategy option, which could subtly change generated output (especially for Rust) or error behavior if upstream semantics shifted.
> 
> **Overview**
> Updates dependency `literalizer` to `2026.4.21.3` (including lockfile updates).
> 
> Adds a new directive option `:heterogeneous-strategy:` and wires it into the extension’s shared format-option parsing/validation, enabling language-specific handling of mixed scalar collections (notably Rust’s `tagged_enum`). Documentation and changelog are updated, and new integration tests cover both unsupported values and the Rust `tagged_enum` rendered output (including preamble generation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf1ab5a7d53458fdf2c49ff754d6ccf116d0ddf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->