### PR TITLE
Bump literalizer to 2026.4.21.4 and wrap ParameterCountMismatchError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Changelog
 Next
 ----
 
+2026.04.21.4
+------------
+
+- Bumped ``literalizer`` to ``2026.4.21.4``.
+- ``literalizer-call`` now reports a parameter/value count mismatch as
+  an ``ExtensionError`` naming the ``:parameter-names:`` option, rather
+  than surfacing literalizer's ``ParameterCountMismatchError`` as a
+  traceback.
+- Picked up the upstream fix for ``pre_indent_level`` interaction with
+  ``:variable-name:``: multi-line values are now uniformly indented
+  under the declaration rather than inserting the pre-indent between
+  ``=`` and the value.
+
 2026.04.21.1
 ------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,8 @@ Next
   traceback.
 - Picked up the upstream fix for ``pre_indent_level`` interaction with
   ``:variable-name:``: multi-line values are now uniformly indented
-  under the declaration rather than inserting the pre-indent between
-  ``=`` and the value.
+  under the declaration rather than inserting the ``pre_indent_level``
+  whitespace between ``=`` and the value.
 
 2026.04.21.1
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.21.3",
+    "literalizer==2026.4.21.4",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -22,6 +22,7 @@ from literalizer import (
     literalize,
     literalize_call,
 )
+from literalizer.exceptions import ParameterCountMismatchError
 from literalizer.languages import ALL_LANGUAGES
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
@@ -512,15 +513,22 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             call_transform = _call_transform
 
         input_format = self._resolve_input_format(data_path=data_path)
-        result = literalize_call(
-            source=data_path.read_text(encoding="utf-8"),
-            input_format=input_format,
-            language=language_spec,
-            target_function=target_function,
-            parameter_names=parameter_names,
-            call_transform=call_transform,
-            per_element=per_element,
-        )
+        try:
+            result = literalize_call(
+                source=data_path.read_text(encoding="utf-8"),
+                input_format=input_format,
+                language=language_spec,
+                target_function=target_function,
+                parameter_names=parameter_names,
+                call_transform=call_transform,
+                per_element=per_element,
+            )
+        except ParameterCountMismatchError as exc:
+            msg = (
+                f"':parameter-names:' has {len(parameter_names)} entries "
+                f"but the data provides a different number of values: {exc}"
+            )
+            raise ExtensionError(message=msg) from exc
 
         code = result.code
         if pre_indent_level > 0:

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4270,3 +4270,47 @@ def test_literalizer_call_call_transform(
     expected_app.cleanup()
 
     assert content_html == expected_html
+
+
+def test_parameter_count_mismatch_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A row whose value count differs from :parameter-names: raises a
+    clear ExtensionError instead of a raw traceback.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1, 2, 3]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: f
+           :parameter-names: a,b
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"':parameter-names:' has 2 entries but the data provides "
+            r"a different number of values: "
+            r"Expected 2 parameters but got 3 values"
+        ),
+    ):
+        app.build()

--- a/uv.lock
+++ b/uv.lock
@@ -623,7 +623,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.21.3"
+version = "2026.4.21.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -631,9 +631,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/c6/7e770165b77120e2c748c6a523f0003fe5051f2eb15f40da293f29a5c596/literalizer-2026.4.21.3.tar.gz", hash = "sha256:73236037dde509aae4b0f70a8e02370b1ee6c3ef3f37c6bf7f0a30ae3551a45f", size = 1136182, upload-time = "2026-04-21T09:51:17.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/a6/e1623791663217ec6107792e5bb9bcd145f7d5fb9bf4284239f4afcdfac4/literalizer-2026.4.21.4.tar.gz", hash = "sha256:d5628fdc71f64b71b3d0b22248dd784d5a139a77ca49062a4c16fe9614720199", size = 1142649, upload-time = "2026-04-21T12:18:33.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/34/aacaad872b74e45d1b6fdd040a85b19dd97b45f091fea7611c4b9bf841e3/literalizer-2026.4.21.3-py3-none-any.whl", hash = "sha256:5276c82d064f80715b064e4ec2ff2c877b5c4bfd8cd704a8dcfb95d2a9fb9b62", size = 385886, upload-time = "2026-04-21T09:51:15.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/38/cd275eac284a3ab00a9c505597d7ac55556d320cdfa4d7815b796894fd96/literalizer-2026.4.21.4-py3-none-any.whl", hash = "sha256:e6755d1f1b0b2081fc94891436b9fa85b1de55aafc1e75e8b5c79a0f8f1d06be", size = 386311, upload-time = "2026-04-21T12:18:31.569Z" },
 ]
 
 [[package]]
@@ -1709,7 +1709,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.21.3" },
+    { name = "literalizer", specifier = "==2026.4.21.4" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.9" },


### PR DESCRIPTION
## Summary

- Bumps the `literalizer` pin from `2026.4.21.3` to `2026.4.21.4` (`pyproject.toml` + `uv.lock`).
- Adopts the release's new `ParameterCountMismatchError`: `literalizer-call` now catches it and re-raises as an `ExtensionError` naming the `:parameter-names:` option, so authors see a clean Sphinx build error instead of a traceback.
- Adds a regression test for the mismatch path and a CHANGELOG entry that also notes the upstream `pre_indent_level` + `NewVariable` fix we now pick up transparently.

## Test plan

- [x] `pytest tests/` (89 passed)
- [x] `ruff check` and `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to dependency pinning and error handling around `literalize_call`, with a regression test added to lock in behavior.
> 
> **Overview**
> Bumps the pinned `literalizer` dependency to `2026.4.21.4` (including lockfile), pulling in upstream formatting behavior fixes noted in the changelog.
> 
> Updates `literalizer-call` to catch `literalizer.exceptions.ParameterCountMismatchError` and re-raise it as a Sphinx `ExtensionError` that explicitly points to `:parameter-names:`; adds an integration test covering this mismatch error path and documents the change in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7874fbba057b7185a569ad813b6fa8c5d81018c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->