### PR TITLE
Expose :call-style: directive option (#145)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- Added a ``:call-style:`` option to select a non-default call style for
+  the ``literalizer-call`` directive (e.g. ``:call-style: positional``
+  for TypeScript to render ``myFunc({...})`` instead of
+  ``myFunc({ obj: {...} })``).
+
 2026.04.22
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -420,6 +420,35 @@ Directive options
       heterogeneous value at the call site (e.g. ``Value::I32(1)``).
       Available for Rust.
 
+``:call-style:`` (optional)
+   How ``literalizer-call`` renders function calls.  Each language
+   offers its own set of call styles; using a value a language does not
+   support raises an error.  Supported values:
+
+   ``positional``
+      Pass arguments by position (e.g. ``myFunc({...})``).  Available
+      for C, C#, C++, Crystal, D, F#, Go, Groovy, HCL, Haskell, Java,
+      JavaScript, Julia, Kotlin, Lua, Perl, PHP, Python, R, Ruby, Rust,
+      Scala, TypeScript.
+   ``keyword``
+      Pass arguments by keyword (e.g. ``my_func(flag=True)``).
+      Available for Crystal, Groovy, Jsonnet, Julia, Kotlin, PHP,
+      Python, R, Ruby, Scala, Swift.
+   ``named``
+      Pass arguments by named colon syntax (e.g.
+      ``MyFunc(flag: true)``).  Available for C#.
+   ``object``
+      Pass arguments as a single object literal (e.g.
+      ``myFunc({ obj: {...} })``).  Available for JavaScript,
+      TypeScript.
+   ``prefix_keyword``
+      Pass arguments as prefixed keyword pairs in an S-expression
+      (e.g. ``(process :flag t)``).  Available for Common Lisp,
+      Racket.
+   ``postfix``
+      Push arguments before naming the function (e.g. ``1 2 ADD``).
+      Available for Forth.
+
 Example
 ~~~~~~~
 

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -3,6 +3,7 @@ Changelog
 Dhall
 Fortran
 Initializer
+Jsonnet
 Lua
 MATLAB
 Mojo

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -68,6 +68,7 @@ _FORMAT_OPTION_GETTERS: dict[
     "line-ending": lambda cls: cls.LineEndings,
     "empty-dict-key": lambda cls: cls.EmptyDictKey,
     "heterogeneous-strategy": lambda cls: cls.HeterogeneousStrategies,
+    "call-style": lambda cls: cls.CallStyles,
 }
 
 
@@ -462,6 +463,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :target-function: my_func
            :parameter-names: flag,count,name
            :per-element:
+           :call-style: keyword
            :call-transform: print($0)
            :input-format: json
            :indent: 4

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4408,6 +4408,90 @@ def test_literalizer_call_common_lisp(
     app.cleanup()
 
 
+def test_call_style_positional_typescript(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :call-style: positional option overrides TypeScript's default
+    OBJECT style so the call drops the parameter-name object wrapper.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"flag": True, "count": 42}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: typescript
+           :target-function: myFunc
+           :parameter-names: obj
+           :call-style: positional
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert 'myFunc({"flag": true, "count": 42});' in text
+    assert "obj:" not in text
+    app.cleanup()
+
+
+def test_call_style_unsupported_value(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :call-style: option rejects values a language does not
+    support.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"flag": True}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: f
+           :parameter-names: obj
+           :call-style: object
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=r"Language 'python' does not support call-style 'object'\.",
+    ):
+        app.build()
+
+
 def test_literalizer_call_without_per_element_uses_call_style(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
## Summary
- Add `call-style` to `_FORMAT_OPTION_GETTERS`, letting authors pick a non-default call style per directive invocation (e.g. `:call-style: positional` for TypeScript).
- Document all six values (`positional`, `keyword`, `named`, `object`, `prefix_keyword`, `postfix`) with per-value language support lists.
- Add tests for the happy path (TypeScript positional) and an unsupported-value error.

Closes #145.

## Test plan
- [x] `pytest tests/test_extension.py` — 95 passed
- [x] `sphinx-build -W docs/source docs/build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to directive option parsing/validation plus docs/tests; existing behavior should remain unchanged unless users opt into `:call-style:`.
> 
> **Overview**
> Adds a new `:call-style:` option to `literalizer-call`, wiring it into the shared format-option pipeline so directives can select a non-default call rendering style (validated per-language with a clear `ExtensionError` on unsupported values).
> 
> Updates documentation and changelog to describe the available call styles and language support, and adds integration tests covering a TypeScript positional override and an unsupported-value failure case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1de6ded7647c266b1b81a4f36ba70d4c8bb297ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->