### PR TITLE
Bump literalizer to 2026.4.23 and cover new features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.4.23``.
+- ``:heterogeneous-strategy: object_variant`` is now available for Nim,
+  auto-generating a Nim object variant in the preamble for dicts,
+  lists, or sibling-list pairs that hold scalars of more than one Nim
+  type.
+- ``:heterogeneous-strategy: union_type`` is now available for Dhall,
+  auto-generating a Dhall union type in the preamble for mixed-scalar
+  containers.
+- ``literalizer-call`` now renders Clojure, Objective-C, and Perl
+  calls: Clojure as ``(process :flag true :count 42)``, Objective-C
+  as ``process(@YES, @(42));`` with boxed scalars, and Perl as
+  ``process(1, 42);``.
+- ``literalizer-call`` now recognizes ``{"$ref": "name"}`` markers at
+  argument positions in the data file, emitting ``name`` as a bare
+  identifier (``process(user=user_obj, count=42)``) rather than
+  formatting the marker dict as a literal.  Refs and literal values
+  can be mixed in the same call across JSON, JSON5, YAML, and TOML.
+
 2026.04.23
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.21.5",
+    "literalizer==2026.4.23",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3231,6 +3231,96 @@ def test_heterogeneous_strategy_tagged_enum(
     app.cleanup()
 
 
+def test_heterogeneous_strategy_object_variant_nim(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Nim's :heterogeneous-strategy: object_variant renders mixed
+    scalars via a generated object variant type.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, "hello"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: nim
+           :heterogeneous-strategy: object_variant
+           :include-delimiters:
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "case kind: ValueKind" in text
+    assert "Value(kind: vkInt, intVal: 1)" in text
+    assert 'Value(kind: vkStr, strVal: "hello")' in text
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_union_type_dhall(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Dhall's :heterogeneous-strategy: union_type renders mixed scalars
+    via a generated Dhall union type.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, "hello"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: dhall
+           :heterogeneous-strategy: union_type
+           :include-delimiters:
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "let Value = < Int : Integer | Str : Text > in" in text
+    assert "Value.Int +1" in text
+    assert 'Value.Str "hello"' in text
+    app.cleanup()
+
+
 def test_unsupported_default_set_element_type_error(
     *,
     make_app: Callable[..., SphinxTestApp],
@@ -4405,6 +4495,187 @@ def test_literalizer_call_common_lisp(
     text = literal_block.astext()
     assert "(process :flag t :count 42)" in text
     assert "(process :flag nil :count 99)" in text
+    app.cleanup()
+
+
+def test_literalizer_call_clojure(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The literalizer-call directive renders Clojure calls as
+    S-expressions with ``:keyword`` arguments.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42], [False, 99]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: clojure
+           :target-function: process
+           :parameter-names: flag,count
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "(process :flag true :count 42)" in text
+    assert "(process :flag false :count 99)" in text
+    app.cleanup()
+
+
+def test_literalizer_call_objective_c(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The literalizer-call directive renders Objective-C calls as
+    positional C-style calls with boxed scalars.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42], [False, 99]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: objective-c
+           :target-function: process
+           :parameter-names: flag,count
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "process(@YES, @(42));" in text
+    assert "process(@NO, @(99));" in text
+    app.cleanup()
+
+
+def test_literalizer_call_perl(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The literalizer-call directive renders Perl calls as positional
+    subroutine invocations.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42], [False, 99]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: perl
+           :target-function: process
+           :parameter-names: flag,count
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "process(1, 42);" in text
+    assert "process(0, 99);" in text
+    app.cleanup()
+
+
+def test_literalizer_call_ref_marker(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``{"$ref": "name"}`` markers at argument positions emit the name
+    as a bare identifier rather than formatting it as a literal.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(
+            obj=[
+                [{"$ref": "user_obj"}, 42],
+                [{"$ref": "admin"}, 99],
+            ],
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: process
+           :parameter-names: user,count
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "process(user=user_obj, count=42)" in text
+    assert "process(user=admin, count=99)" in text
     app.cleanup()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.21.5"
+version = "2026.4.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -635,9 +635,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/5a/3b5075e4419fb34ae1a1f2fcd075bc145175516119feb35e68656d9636e8/literalizer-2026.4.21.5.tar.gz", hash = "sha256:c6f47da7abdb7c58f728dca838413c43f4681ca93ecc3b399956e548cd7d939e", size = 1158587, upload-time = "2026-04-21T21:33:52.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/88/af0e694d9b914a09e1c3b6e12ad41a50aa9b303bdec8f29b3f1d2a0a4879/literalizer-2026.4.23.tar.gz", hash = "sha256:9ee5425692f9eb9740c900f1a180b7bbbb66cfed8a334012698308b4822b0913", size = 1276168, upload-time = "2026-04-23T16:50:27.865Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/85/0e7445b7a44faecb68f545fa43df1b836ef41068a3bcb1c8c12c88573eb3/literalizer-2026.4.21.5-py3-none-any.whl", hash = "sha256:b1f21c828f90c1f53d483880a37500ff1db492aa9e7af06761b5e05abb189060", size = 388660, upload-time = "2026-04-21T21:33:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/3d/8cc2ef6063aad5525406005769d50262f52cacbf4592ca13a22a092b181f/literalizer-2026.4.23-py3-none-any.whl", hash = "sha256:5c936fd9b986afb92acf0f3973843c3b5aaac0b827c2c850cb25ce18cbdc79db", size = 408234, upload-time = "2026-04-23T16:50:25.992Z" },
 ]
 
 [[package]]
@@ -1713,7 +1713,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.21.5" },
+    { name = "literalizer", specifier = "==2026.4.23" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.10" },


### PR DESCRIPTION
## Summary
- Bump ``literalizer`` to ``2026.4.23``.
- Surface new upstream features via existing directive options: Nim ``:heterogeneous-strategy: object_variant``, Dhall ``:heterogeneous-strategy: union_type``, ``literalizer-call`` rendering for Clojure / Objective-C / Perl, and ``{"$ref": "name"}`` markers at call argument positions.
- Extension code is unchanged — the directives already expose new language enums dynamically; six new tests in ``tests/test_extension.py`` exercise each feature end-to-end.

## Test plan
- [x] ``uv run pytest tests/`` — 101 passed
- [x] ``uv run ruff check`` — clean
- [x] ``uv run mypy`` — clean
- [x] ``uv run sphinx-build -b spelling`` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades the core `literalizer` dependency, which can change rendered output across languages, though coverage is expanded with new integration tests.
> 
> **Overview**
> Updates the `literalizer` dependency to `2026.4.23` (including lockfile changes) and documents the new upstream capabilities in `CHANGELOG.rst`.
> 
> Adds end-to-end tests proving the extension now surfaces new upstream rendering behaviors via existing directive options: Nim `:heterogeneous-strategy: object_variant`, Dhall `:heterogeneous-strategy: union_type`, `literalizer-call` output for Clojure/Objective-C/Perl, and `{"$ref": "name"}` call-argument markers emitting bare identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9e05d5d6a3f3b783739ff376302b33629910280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->