### PR TITLE
Bump literalizer to 2026.4.24.1 and expose new features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,36 @@ Changelog
 Next
 ----
 
-2026.04.24
-----------
+2026.04.24.1
+------------
 
+
+- Bumped ``literalizer`` to ``2026.4.24.1``.
+- Added ``:ref-case:`` option to ``literalizer-call`` that converts
+  ``{"$ref": "name"}`` identifiers to the target language's idiomatic
+  case at render time (``snake``, ``camel``, ``pascal``,
+  ``upper_snake``, ``kebab``).  Using a case the language does not
+  support raises an ``ExtensionError``.
+- Added ``:wrap-in-file:`` flag to ``literalizer-call`` that injects a
+  no-op stub for the target function into the generated source so it
+  compiles against strict checkers on its own.
+- ``literalizer-call`` now renders Bash command invocations
+  (``target arg1 arg2``) via Bash's ``command`` call style, and
+  translates ``CallArgNotSupportedError`` (raised for lists, dicts, or
+  sets passed as Bash call arguments) into an ``ExtensionError``.
+- ``literalizer-call`` now renders Erlang positional calls and Gleam
+  positional calls (dotted Gleam targets like ``app.client.fetch``
+  are flattened to ``app_client_fetch``).
+- ``:heterogeneous-strategy: variant`` is now available for Mojo,
+  auto-generating a ``comptime Value = Variant[...]`` alias in the
+  preamble for dicts, lists, or sibling-list pairs that hold scalars
+  of more than one Mojo type.
+- Errors raised by ``literalizer-call`` when the selected language has
+  no call support (``CallsNotSupportedByLanguageError`` for data/markup
+  formats and ``CallsNotSupportedByToolError`` for programming
+  languages that literalizer does not yet implement calls for) are now
+  translated into an ``ExtensionError`` instead of surfacing as a
+  traceback.
 
 2026.04.24
 ----------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -415,21 +415,38 @@ Directive options
    ``error``
       Raise an error when a collection mixes scalar types (default for
       all languages).
+   ``object_variant``
+      Emit a Nim object variant in the preamble and wrap each
+      heterogeneous value at the call site (e.g.
+      ``Value(kind: vkInt, intVal: 1)``).  Available for Nim.
    ``tagged_enum``
       Emit a minimal tagged ``enum`` in the preamble and wrap each
       heterogeneous value at the call site (e.g. ``Value::I32(1)``).
       Available for Rust.
+   ``union_type``
+      Emit a Dhall union type in the preamble and wrap each
+      heterogeneous value at the call site (e.g. ``Value.Int 1``).
+      Available for Dhall.
+   ``variant``
+      Emit a Mojo ``Variant`` type alias in the preamble and wrap each
+      heterogeneous value at the call site (e.g. ``Value(1)``).
+      Available for Mojo.
 
 ``:call-style:`` (optional)
    How ``literalizer-call`` renders function calls.  Each language
    offers its own set of call styles; using a value a language does not
    support raises an error.  Supported values:
 
+   ``command``
+      Render calls as a command invocation with space-separated
+      arguments and no surrounding parentheses (e.g.
+      ``target arg1 arg2``).  Available for Bash.
    ``positional``
       Pass arguments by position (e.g. ``myFunc({...})``).  Available
-      for C, C#, C++, Crystal, D, F#, Go, Groovy, HCL, Haskell, Java,
-      JavaScript, Julia, Kotlin, Lua, Perl, PHP, Python, R, Ruby, Rust,
-      Scala, TypeScript.
+      for C, C#, C++, Clojure-style languages that support it, Crystal,
+      D, Erlang, F#, Gleam, Go, Groovy, HCL, Haskell, Java, JavaScript,
+      Julia, Kotlin, Lua, Objective-C, Perl, PHP, Python, R, Ruby,
+      Rust, Scala, TypeScript.
    ``keyword``
       Pass arguments by keyword (e.g. ``my_func(flag=True)``).
       Available for Crystal, Groovy, Jsonnet, Julia, Kotlin, PHP,
@@ -443,8 +460,8 @@ Directive options
       TypeScript.
    ``prefix_keyword``
       Pass arguments as prefixed keyword pairs in an S-expression
-      (e.g. ``(process :flag t)``).  Available for Common Lisp,
-      Racket.
+      (e.g. ``(process :flag t)``).  Available for Clojure, Common
+      Lisp, Racket.
    ``postfix``
       Push arguments before naming the function (e.g. ``1 2 ADD``).
       Available for Forth.
@@ -539,6 +556,32 @@ For positional-call languages like Go, the same data renders as:
    When set, each top-level list element becomes a separate function
    call.  Without this flag, the whole literalized value is passed as a
    single argument.
+
+``:ref-case:`` (optional)
+   Convert ``{"$ref": "name"}`` ref identifiers to the target
+   language's idiomatic identifier case at render time.  When not set,
+   ref names are emitted verbatim.  Each language exposes only the
+   subset of cases it understands; passing an unsupported case raises
+   an ``ExtensionError``.  Supported values:
+
+   ``snake``
+      Convert to ``snake_case`` (e.g. ``user_obj``).
+   ``camel``
+      Convert to ``camelCase`` (e.g. ``userObj``).
+   ``pascal``
+      Convert to ``PascalCase`` (e.g. ``UserObj``).
+   ``upper_snake``
+      Convert to ``UPPER_SNAKE_CASE`` (e.g. ``USER_OBJ``).
+   ``kebab``
+      Convert to ``kebab-case`` (e.g. ``user-obj``).
+
+``:wrap-in-file:`` (optional flag)
+   When set, ``literalizer-call`` emits a complete source file for the
+   target language, including a no-op stub definition of the target
+   function so the generated source compiles against strict checkers on
+   its own.  Callers that supply ``:call-transform:`` remain
+   responsible for providing the wrapper function introduced by the
+   transform.
 
 The ``literalizer-call`` directive also supports these shared options
 from the ``literalizer`` directive: ``:language:``, ``:input-format:``,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.24",
+    "literalizer==2026.4.24.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -15,6 +15,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from literalizer import (
     ExistingVariable,
+    IdentifierCase,
     InputFormat,
     Language,
     LanguageCls,
@@ -22,7 +23,13 @@ from literalizer import (
     literalize,
     literalize_call,
 )
-from literalizer.exceptions import ParameterCountMismatchError
+from literalizer.exceptions import (
+    CallArgNotSupportedError,
+    CallsNotSupportedByLanguageError,
+    CallsNotSupportedByToolError,
+    ParameterCountMismatchError,
+    UnsupportedIdentifierCaseError,
+)
 from literalizer.languages import ALL_LANGUAGES
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
@@ -465,6 +472,8 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :per-element:
            :call-style: keyword
            :call-transform: print($0)
+           :ref-case: snake
+           :wrap-in-file:
            :input-format: json
            :indent: 4
            :indent-char: spaces
@@ -477,6 +486,11 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         "parameter-names": directives.unchanged_required,
         "per-element": directives.flag,
         "call-transform": directives.unchanged_required,
+        "ref-case": lambda x: directives.choice(
+            argument=x,
+            values=tuple(member.value for member in IdentifierCase),
+        ),
+        "wrap-in-file": directives.flag,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -514,6 +528,13 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
             call_transform = _call_transform
 
+        ref_case_value: str | None = self.options.get("ref-case")
+        ref_case: IdentifierCase | None = None
+        if ref_case_value is not None:
+            ref_case = IdentifierCase(value=ref_case_value)
+
+        wrap_in_file: bool = "wrap-in-file" in self.options
+
         input_format = self._resolve_input_format(data_path=data_path)
         try:
             result = literalize_call(
@@ -524,11 +545,34 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                 parameter_names=parameter_names,
                 call_transform=call_transform,
                 per_element=per_element,
+                wrap_in_file=wrap_in_file,
+                ref_case=ref_case,
             )
         except ParameterCountMismatchError as exc:
             msg = (
                 f"':parameter-names:' has {len(parameter_names)} entries "
                 f"but the data provides a different number of values: {exc}"
+            )
+            raise ExtensionError(message=msg) from exc
+        except UnsupportedIdentifierCaseError as exc:
+            msg = (
+                f"Language '{language_name}' does not support "
+                f"ref-case '{ref_case_value}'."
+            )
+            raise ExtensionError(message=msg) from exc
+        except CallArgNotSupportedError as exc:
+            msg = (
+                f"Language '{language_name}' does not support the given "
+                f"call argument: {exc}"
+            )
+            raise ExtensionError(message=msg) from exc
+        except (
+            CallsNotSupportedByLanguageError,
+            CallsNotSupportedByToolError,
+        ) as exc:
+            msg = (
+                f"Language '{language_name}' does not support "
+                f"'literalizer-call': {exc}"
             )
             raise ExtensionError(message=msg) from exc
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4847,3 +4847,348 @@ def test_parameter_count_mismatch_error(
         ),
     ):
         app.build()
+
+
+def test_literalizer_call_ref_case(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :ref-case: option converts ``$ref`` identifiers to the
+    target language's idiomatic case.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[{"$ref": "user_obj"}, 42]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: go
+           :target-function: process
+           :parameter-names: user,count
+           :per-element:
+           :ref-case: pascal
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "process(UserObj, 42)" in text
+    app.cleanup()
+
+
+def test_literalizer_call_ref_case_unsupported(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Using a ``:ref-case:`` value the language does not understand
+    raises an ``ExtensionError``.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[{"$ref": "user_obj"}]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: erlang
+           :target-function: f
+           :parameter-names: user
+           :per-element:
+           :ref-case: camel
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=r"Language 'erlang' does not support ref-case 'camel'\.",
+    ):
+        app.build()
+
+
+def test_literalizer_call_wrap_in_file(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :wrap-in-file: flag emits a stub definition for the target
+    function alongside the call expression.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1, 2]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: f
+           :parameter-names: a,b
+           :per-element:
+           :wrap-in-file:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "def f(" in text
+    assert "f(a=1, b=2)" in text
+    app.cleanup()
+
+
+def test_literalizer_call_bash_command_style(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Bash ``literalizer-call`` renders command-style invocations
+    (space-separated arguments, no parentheses).
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1, 2]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: bash
+           :target-function: mycmd
+           :parameter-names: a,b
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "mycmd 1 2" in text
+    app.cleanup()
+
+
+def test_literalizer_call_bash_rejects_list_arg(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Bash has no inline compound-literal syntax in command
+    invocations, so passing a list as an argument raises an
+    ``ExtensionError``.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[[1, 2, 3]]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: bash
+           :target-function: cmd
+           :parameter-names: a
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=r"Language 'bash' does not support the given call argument",
+    ):
+        app.build()
+
+
+def test_literalizer_call_erlang(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Erlang ``literalizer-call`` renders positional calls separated
+    by ``,`` and terminated by ``.``.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1, 2], [3, 4]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: erlang
+           :target-function: my_func
+           :parameter-names: a,b
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "my_func(1, 2)" in text
+    assert "my_func(3, 4)" in text
+    app.cleanup()
+
+
+def test_literalizer_call_gleam(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Gleam ``literalizer-call`` renders positional calls, and
+    flattens dotted targets to underscored identifiers.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1, 2]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: gleam
+           :target-function: app.client.fetch
+           :parameter-names: a,b
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "app_client_fetch(" in text
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_variant_mojo(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :heterogeneous-strategy: variant option for Mojo wraps
+    mixed scalars in an auto-generated ``Variant`` type alias.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1, "b": "x"}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: mojo
+           :heterogeneous-strategy: variant
+           :include-delimiters:
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "Variant" in text
+    assert "Value(1)" in text
+    app.cleanup()

--- a/uv.lock
+++ b/uv.lock
@@ -627,17 +627,18 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.24"
+version = "2026.4.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
+    { name = "pyhumps" },
     { name = "pyjson5" },
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/bb/918190a5bd7c0263052c6f3e3c5dc275a0315901afb5196d8cf9fed1772c/literalizer-2026.4.24.tar.gz", hash = "sha256:b1b7ddf725a8fa451c745c9b544c3edc6d3b91fedd7942aed5de3bbf70718905", size = 1277645, upload-time = "2026-04-24T03:00:42.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/50/e4b2d5837ff9096e24dd66d5b8af67b6ef202284c7407f5b382dd1133379/literalizer-2026.4.24.1.tar.gz", hash = "sha256:0293c71e15910b9c3d051f643e88d1171efcd31da35ea6d4f859cd05b2314034", size = 1314626, upload-time = "2026-04-24T09:01:16.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/f2/22468589673ffe765a4da98cdd62faa83cb70bad63d24e6a6dbe08fd1d66/literalizer-2026.4.24-py3-none-any.whl", hash = "sha256:5426009fbc2a958ea566488bf45e9521f6c3b5111a8e191c9c32fdb3cbf9b22d", size = 408615, upload-time = "2026-04-24T03:00:39.407Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d8/32d934f6e3121d5d45462078d8c45542700c2a87e60aee7fd82b29c2aa6c/literalizer-2026.4.24.1-py3-none-any.whl", hash = "sha256:d0e6c29eb65d80ce94c16c3d8f3eec3ed13f1ca0ff9f4bb3004633206061bc53", size = 419599, upload-time = "2026-04-24T09:01:13.926Z" },
 ]
 
 [[package]]
@@ -1064,6 +1065,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyhumps"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/83/fa6f8fb7accb21f39e8f2b6a18f76f6d90626bdb0a5e5448e5cc9b8ab014/pyhumps-3.8.0.tar.gz", hash = "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3", size = 9018, upload-time = "2022-10-21T10:38:59.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/11/a1938340ecb32d71e47ad4914843775011e6e9da59ba1229f181fef3119e/pyhumps-3.8.0-py3-none-any.whl", hash = "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6", size = 6095, upload-time = "2022-10-21T10:38:58.231Z" },
 ]
 
 [[package]]
@@ -1713,7 +1723,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.24" },
+    { name = "literalizer", specifier = "==2026.4.24.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.10" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bumps the ``literalizer`` dependency from ``2026.4.24`` to ``2026.4.24.1`` and wires through the user-visible additions from that release.

## New directive options

- ``:ref-case:`` on ``literalizer-call`` converts ``{"$ref": "name"}`` identifiers to the target language's idiomatic identifier case at render time (``snake``, ``camel``, ``pascal``, ``upper_snake``, ``kebab``). The same YAML source can now drive multiple languages without re-authoring the ref names (e.g. ``user_obj`` → ``UserObj`` for Go via ``:ref-case: pascal``). Passing a case the language does not understand raises an ``ExtensionError`` naming the directive option.
- ``:wrap-in-file:`` on ``literalizer-call`` emits a no-op stub for the target function alongside the generated calls so the generated source compiles against strict checkers on its own.

## Newly surfaced call-style / heterogeneous-strategy values

These are already valid inputs once the upstream bump lands; the directive docs are updated to list them:

- ``:call-style: command`` for Bash (``target arg1 arg2``).
- ``literalizer-call`` for Erlang (positional calls) and Gleam (positional calls, dotted targets flattened to underscored identifiers).
- ``:heterogeneous-strategy: variant`` for Mojo (``comptime Value = Variant[...]``).

## Error translation

Newly-added literalizer exceptions are translated into ``ExtensionError`` with directive-aware messages instead of surfacing as tracebacks:

- ``CallArgNotSupportedError`` (e.g. passing a list as a Bash call argument).
- ``UnsupportedIdentifierCaseError`` (e.g. ``:ref-case: camel`` for Erlang).
- ``CallsNotSupportedByLanguageError`` / ``CallsNotSupportedByToolError``.

## Tests

Added integration tests for ``:ref-case:``, ``:wrap-in-file:``, Bash command-style calls, Bash's list-argument rejection, Erlang/Gleam calls, and the Mojo ``variant`` heterogeneous strategy. All 109 tests pass and ``mypy``, ``pyright``, ``ruff check``, ``ruff format``, ``doc8``, ``sphinx-lint``, and the docs build are clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b06ee8a-c242-47aa-8efa-1b2d29082cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b06ee8a-c242-47aa-8efa-1b2d29082cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

