### PR TITLE
Add :ref-case: option to literalizer-call (bump literalizer to 2026.4.24.1)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.4.24.1``.
+- ``literalizer-call`` now accepts ``:ref-case:`` (``snake``, ``camel``,
+  ``pascal``, ``upper_snake``, or ``kebab``) to convert
+  ``{"$ref": "name"}`` identifiers to the chosen case before rendering.
+
 2026.04.24
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.24",
+    "literalizer==2026.4.24.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -15,6 +15,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from literalizer import (
     ExistingVariable,
+    IdentifierCase,
     InputFormat,
     Language,
     LanguageCls,
@@ -70,6 +71,11 @@ _FORMAT_OPTION_GETTERS: dict[
     "heterogeneous-strategy": lambda cls: cls.HeterogeneousStrategies,
     "call-style": lambda cls: cls.CallStyles,
 }
+
+
+_IDENTIFIER_CASE_VALUES: tuple[str, ...] = tuple(
+    sorted(m.name.lower() for m in IdentifierCase)
+)
 
 
 @cache
@@ -469,6 +475,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :indent: 4
            :indent-char: spaces
            :include-preamble:
+           :ref-case: camel
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -477,6 +484,10 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         "parameter-names": directives.unchanged_required,
         "per-element": directives.flag,
         "call-transform": directives.unchanged_required,
+        "ref-case": lambda x: directives.choice(
+            argument=x,
+            values=_IDENTIFIER_CASE_VALUES,
+        ),
     }
 
     def run(self) -> list[nodes.Node]:
@@ -514,6 +525,13 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
             call_transform = _call_transform
 
+        ref_case_value: str | None = self.options.get("ref-case")
+        ref_case: IdentifierCase | None = (
+            None
+            if ref_case_value is None
+            else IdentifierCase[ref_case_value.upper()]
+        )
+
         input_format = self._resolve_input_format(data_path=data_path)
         try:
             result = literalize_call(
@@ -524,6 +542,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                 parameter_names=parameter_names,
                 call_transform=call_transform,
                 per_element=per_element,
+                ref_case=ref_case,
             )
         except ParameterCountMismatchError as exc:
             msg = (

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4630,6 +4630,59 @@ def test_literalizer_call_perl(
     app.cleanup()
 
 
+def test_literalizer_call_ref_case_camel(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:ref-case: camel`` converts ``{"$ref": "name"}`` identifiers
+    to camelCase in the rendered call.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(
+            obj=[
+                [{"$ref": "user_obj"}, 42],
+                [{"$ref": "admin_user"}, 99],
+            ],
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: typescript
+           :target-function: process
+           :parameter-names: user,count
+           :per-element:
+           :ref-case: camel
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    expected = (
+        "process({ user: userObj, count: 42 });\n"
+        "process({ user: adminUser, count: 99 });"
+    )
+    assert text == expected
+    app.cleanup()
+
+
 def test_literalizer_call_ref_marker(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -627,17 +627,18 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.24"
+version = "2026.4.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
+    { name = "pyhumps" },
     { name = "pyjson5" },
     { name = "ruamel-yaml" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/bb/918190a5bd7c0263052c6f3e3c5dc275a0315901afb5196d8cf9fed1772c/literalizer-2026.4.24.tar.gz", hash = "sha256:b1b7ddf725a8fa451c745c9b544c3edc6d3b91fedd7942aed5de3bbf70718905", size = 1277645, upload-time = "2026-04-24T03:00:42.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/50/e4b2d5837ff9096e24dd66d5b8af67b6ef202284c7407f5b382dd1133379/literalizer-2026.4.24.1.tar.gz", hash = "sha256:0293c71e15910b9c3d051f643e88d1171efcd31da35ea6d4f859cd05b2314034", size = 1314626, upload-time = "2026-04-24T09:01:16.314Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/f2/22468589673ffe765a4da98cdd62faa83cb70bad63d24e6a6dbe08fd1d66/literalizer-2026.4.24-py3-none-any.whl", hash = "sha256:5426009fbc2a958ea566488bf45e9521f6c3b5111a8e191c9c32fdb3cbf9b22d", size = 408615, upload-time = "2026-04-24T03:00:39.407Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d8/32d934f6e3121d5d45462078d8c45542700c2a87e60aee7fd82b29c2aa6c/literalizer-2026.4.24.1-py3-none-any.whl", hash = "sha256:d0e6c29eb65d80ce94c16c3d8f3eec3ed13f1ca0ff9f4bb3004633206061bc53", size = 419599, upload-time = "2026-04-24T09:01:13.926Z" },
 ]
 
 [[package]]
@@ -1064,6 +1065,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyhumps"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/83/fa6f8fb7accb21f39e8f2b6a18f76f6d90626bdb0a5e5448e5cc9b8ab014/pyhumps-3.8.0.tar.gz", hash = "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3", size = 9018, upload-time = "2022-10-21T10:38:59.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/11/a1938340ecb32d71e47ad4914843775011e6e9da59ba1229f181fef3119e/pyhumps-3.8.0-py3-none-any.whl", hash = "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6", size = 6095, upload-time = "2022-10-21T10:38:58.231Z" },
 ]
 
 [[package]]
@@ -1713,7 +1723,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.24" },
+    { name = "literalizer", specifier = "==2026.4.24.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.10" },


### PR DESCRIPTION
## Summary

- Bumps ``literalizer`` to ``2026.4.24.1``, which adds a ``ref_case`` parameter to ``literalize_call`` backed by a global ``IdentifierCase`` enum (``SNAKE``/``CAMEL``/``PASCAL``/``UPPER_SNAKE``/``KEBAB``).
- Adds a ``:ref-case:`` directive option on ``literalizer-call`` so authors can keep a canonical spelling in the data file (e.g. ``user_obj``) and have ``{"$ref": "name"}`` markers render in the target language's convention.
- New test ``test_literalizer_call_ref_case_camel`` exercises ``:ref-case: camel`` end-to-end against TypeScript.

## Test plan

- [x] ``pytest tests/test_extension.py`` — 102 passed
- [ ] Manual: render a YAML with ``$ref: user_obj`` across Python, TypeScript, and Rust docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is opt-in via a new directive option and mainly wires through an upstream `literalizer` API update plus a dependency bump.
> 
> **Overview**
> `literalizer-call` now accepts a new `:ref-case:` option to transform `{"$ref": "name"}` identifiers into a chosen naming convention (e.g. `camel`, `snake`) before rendering calls.
> 
> This PR bumps `literalizer` to `2026.4.24.1` to pick up the upstream `IdentifierCase`/`ref_case` support, updates docs/changelog accordingly, and adds an end-to-end test covering TypeScript camelCase ref rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61f7d4d630624cc834fcf3650270b81725bea932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->