### PR TITLE
Use importlib.metadata for extension version

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -7,6 +7,7 @@ read data files and render them as native language code blocks.
 import enum
 from collections.abc import Callable, Iterable
 from functools import cache, partial
+from importlib.metadata import version
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -620,7 +621,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         cls=LiteralizerCallDirective,
     )
     return {
-        "version": "0.1.0",
+        "version": version(distribution_name="sphinx-literalizer"),
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }


### PR DESCRIPTION
Replace the hardcoded `"0.1.0"` version string in `setup()` with a dynamic lookup via `importlib.metadata.version`, so the version reported to Sphinx always matches the installed package version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only affects the version string reported to Sphinx; behavior is otherwise unchanged. Potential risk is limited to misconfigured distribution metadata causing version lookup failures at runtime.
> 
> **Overview**
> Updates the Sphinx extension `setup()` metadata to report its version dynamically via `importlib.metadata.version("sphinx-literalizer")` instead of a hardcoded string, keeping Sphinx’s reported extension version in sync with the installed package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598cab82d8a5d866604487dca2519e5135a076a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->