### PR TITLE
Add :both-variable-forms: option to literalizer directive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 Next
 ----
 
+- Added ``:both-variable-forms:`` to the ``literalizer`` directive.
+  When combined with ``:variable-name:`` and ``:wrap-in-file:``, it uses
+  literalizer's ``BothVariableForms`` to emit both a declaration and an
+  assignment in a single output block.
+
 2026.04.30
 ----------
 

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -14,6 +14,7 @@ from beartype import beartype
 from docutils import nodes
 from docutils.parsers.rst import directives
 from literalizer import (
+    BothVariableForms,
     ExistingVariable,
     IdentifierCase,
     InputFormat,
@@ -380,6 +381,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :datetime-format: python
            :variable-name: my_var
            :existing-variable:
+           :both-variable-forms:
            :sequence-format: list
            :set-format: frozenset
            :bytes-format: python
@@ -414,6 +416,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         "include-delimiters": directives.flag,
         "variable-name": directives.unchanged,
         "existing-variable": directives.flag,
+        "both-variable-forms": directives.flag,
         "modifiers": directives.unchanged,
     }
 
@@ -436,6 +439,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         include_preamble: bool = "include-preamble" in self.options
         variable_name: str | None = self.options.get("variable-name")
         existing_variable: bool = "existing-variable" in self.options
+        both_variable_forms: bool = "both-variable-forms" in self.options
         modifiers_value: str | None = self.options.get("modifiers")
 
         if modifiers_value is not None and variable_name is None:
@@ -444,6 +448,21 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         if modifiers_value is not None and existing_variable:
             msg = (
                 "':modifiers:' cannot be combined with ':existing-variable:'."
+            )
+            raise ExtensionError(message=msg)
+        if modifiers_value is not None and both_variable_forms:
+            msg = (
+                "':modifiers:' cannot be combined with "
+                "':both-variable-forms:'."
+            )
+            raise ExtensionError(message=msg)
+        if both_variable_forms and variable_name is None:
+            msg = "':both-variable-forms:' requires ':variable-name:'."
+            raise ExtensionError(message=msg)
+        if both_variable_forms and existing_variable:
+            msg = (
+                "':both-variable-forms:' cannot be combined with "
+                "':existing-variable:'."
             )
             raise ExtensionError(message=msg)
 
@@ -457,11 +476,18 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
 
         variable_form = None
         if variable_name is not None:
-            variable_form = (
-                ExistingVariable(name=variable_name)
-                if existing_variable
-                else NewVariable(name=variable_name, modifiers=modifiers)
-            )
+            if existing_variable:
+                variable_form = ExistingVariable(name=variable_name)
+            elif both_variable_forms:
+                variable_form = BothVariableForms(
+                    name=variable_name,
+                    modifiers=modifiers,
+                )
+            else:
+                variable_form = NewVariable(
+                    name=variable_name,
+                    modifiers=modifiers,
+                )
 
         wrap_in_file: bool = "wrap-in-file" in self.options
         ref_case_value: str | None = self.options.get("ref-case")

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -21,6 +21,7 @@ from literalizer import (
     Language,
     LanguageCls,
     NewVariable,
+    VariableForm,
     literalize,
     literalize_call,
 )
@@ -474,7 +475,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
                 value=modifiers_value,
             )
 
-        variable_form = None
+        variable_form: VariableForm | None = None
         if variable_name is not None:
             if existing_variable:
                 variable_form = ExistingVariable(name=variable_name)

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1454,6 +1454,48 @@ def test_modifiers_with_existing_variable_error(
         app.build()
 
 
+def test_modifiers_with_both_variable_forms_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Combining :modifiers: with :both-variable-forms: raises an
+    ExtensionError.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: java
+           :variable-name: myList
+           :both-variable-forms:
+           :modifiers: public
+           :wrap-in-file:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"^':modifiers:' cannot be combined with "
+            r"':both-variable-forms:'\.$"
+        ),
+    ):
+        app.build()
+
+
 def test_rust_language(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4973,3 +4973,122 @@ def test_module_name_unsupported_language_error(
         match=r"Language 'python' does not support ':module-name:'\.",
     ):
         app.build()
+
+
+def test_both_variable_forms_csharp(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :both-variable-forms: flag emits declaration and assignment."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj={"x": 1}))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: csharp
+           :variable-name: my_var
+           :both-variable-forms:
+           :wrap-in-file:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "var my_var" in text
+    assert "my_var =" in text
+    app.cleanup()
+
+
+def test_both_variable_forms_requires_variable_name(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Using :both-variable-forms: without :variable-name: raises an
+    ExtensionError.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj={"x": 1}))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :both-variable-forms:
+           :wrap-in-file:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=r"^':both-variable-forms:' requires ':variable-name:'\.$",
+    ):
+        app.build()
+
+
+def test_both_variable_forms_incompatible_with_existing_variable(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Combining :both-variable-forms: with :existing-variable: raises an
+    ExtensionError.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj={"x": 1}))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :variable-name: my_var
+           :existing-variable:
+           :both-variable-forms:
+           :wrap-in-file:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"^':both-variable-forms:' cannot be combined with "
+            r"':existing-variable:'\.$"
+        ),
+    ):
+        app.build()


### PR DESCRIPTION
## Summary

- Exposes literalizer's `BothVariableForms` via a new `:both-variable-forms:` flag on the `literalizer` directive, emitting both a variable declaration and assignment in a single output block (requires `:variable-name:` and `:wrap-in-file:`).
- Raises clear `ExtensionError` when `:both-variable-forms:` is used without `:variable-name:`, or combined with `:existing-variable:` or `:modifiers:`.
- Adds 3 integration tests covering the happy path (C#), missing `:variable-name:`, and incompatibility with `:existing-variable:`.

## Test plan

- [ ] `pytest tests/` passes (107 tests)
- [ ] Test `test_both_variable_forms_csharp` verifies both declaration and assignment appear in output
- [ ] Tests for error cases confirm correct `ExtensionError` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive option-gating change limited to Sphinx directive parsing/rendering, with new integration tests covering both success and failure paths.
> 
> **Overview**
> Adds a new `:both-variable-forms:` flag to the `literalizer` directive, wiring through to literalizer’s `BothVariableForms` so output can include *both* a variable declaration and a subsequent assignment in the same rendered block.
> 
> Introduces validation errors for invalid option combinations (requires `:variable-name:`; incompatible with `:existing-variable:` and `:modifiers:`) and adds integration tests covering the C# happy path plus the new error cases. Updates the changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c69999878a9ecfe035ce2256bd2333f185c3a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->