### PR TITLE
Add :consumable-refs: to literalizer-call; bump literalizer to 2026.4.30.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.4.30.2``.
+- Added ``:consumable-refs:`` option to the ``literalizer-call`` directive.
+  Accepts a comma-separated list of variable names that may be consumed
+  (moved) when they appear as ``$ref`` markers in exactly one call argument
+  across all rendered calls. For languages such as C++ and Mojo, this causes
+  the matching ``std::move``/``^`` transfer to be emitted.
+
 2026.04.30.1
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.30",
+    "literalizer==2026.4.30.2",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -548,6 +548,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :include-preamble:
            :ref-case: camel
            :module-name: MyModule
+           :consumable-refs: my_var,other_var
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -556,6 +557,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         "parameter-names": directives.unchanged_required,
         "per-element": directives.flag,
         "call-transform": directives.unchanged_required,
+        "consumable-refs": directives.unchanged,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -600,6 +602,17 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             else IdentifierCase[ref_case_value.upper()]
         )
 
+        consumable_refs_value: str | None = self.options.get("consumable-refs")
+        consumable_refs: frozenset[str] = (
+            frozenset()
+            if consumable_refs_value is None
+            else frozenset(
+                r.strip()
+                for r in consumable_refs_value.split(",")
+                if r.strip()
+            )
+        )
+
         input_format = self._resolve_input_format(data_path=data_path)
         try:
             result = literalize_call(
@@ -611,6 +624,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                 call_transform=call_transform,
                 per_element=per_element,
                 ref_case=ref_case,
+                consumable_refs=consumable_refs,
             )
         except ParameterCountMismatchError as exc:
             msg = (

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -608,7 +608,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             if consumable_refs_value is None
             else frozenset(
                 r.strip()
-                for r in consumable_refs_value.split(",")
+                for r in consumable_refs_value.split(sep=",")
                 if r.strip()
             )
         )

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5134,3 +5134,47 @@ def test_both_variable_forms_incompatible_with_existing_variable(
         ),
     ):
         app.build()
+
+
+def test_literalizer_call_consumable_refs(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:consumable-refs: causes refs used exactly once to be consumed
+    (e.g. wrapped in ``std::move`` for C++).
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[{"$ref": "my_vec"}, 42]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: cpp
+           :target-function: process
+           :parameter-names: data,count
+           :per-element:
+           :consumable-refs: my_vec
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "std::move(my_vec)" in text
+    app.cleanup()

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.30"
+version = "2026.4.30.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -637,9 +637,9 @@ dependencies = [
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/ca/1e86f0f8099fd945e59f5f51dd116d217d894ab9e3939304f6169ecb2e8e/literalizer-2026.4.30.tar.gz", hash = "sha256:584469131a9ada106581a33d3cb54183d3463433285f0cb98934b6cf759684e9", size = 1565809, upload-time = "2026-04-30T02:26:00.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8c/cf4c13bbd60e4df1f23117bd2e94bb5330e32e58601b3d79c7900264caee/literalizer-2026.4.30.2.tar.gz", hash = "sha256:91269dfee8d488fcf7204841d62f10009deb86769ea233193ba02fa099777c0f", size = 1636198, upload-time = "2026-04-30T10:30:10.835Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/3f/51c6aaaba14b0634d9c0d697e46a839dbbbfcabd97646206dc32471871b2/literalizer-2026.4.30-py3-none-any.whl", hash = "sha256:e28e6bcf46f9ece548137cf6f61e373c14c4c8379198768c8e66902d907b3131", size = 477528, upload-time = "2026-04-30T02:25:58.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b0/def520f98511c26abae94a6b3d06796d4d15b0cbfdf141598d6c9ab7c877/literalizer-2026.4.30.2-py3-none-any.whl", hash = "sha256:ac66bdd1c04183cc641ab3b2db25e49c8747d34a3e23a52e69c99061b162aaf9", size = 490377, upload-time = "2026-04-30T10:30:09.021Z" },
 ]
 
 [[package]]
@@ -1762,7 +1762,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.30" },
+    { name = "literalizer", specifier = "==2026.4.30.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.11" },


### PR DESCRIPTION
## Summary

- Bumps `literalizer` from `2026.4.30` to `2026.4.30.2`, which adds `consumable_refs` support to `literalize_call` (fixing C++ and Mojo use-after-move on shared `$ref` variables).
- Adds `:consumable-refs:` option to the `literalizer-call` directive, accepting a comma-separated list of variable names; refs in that set that appear in exactly one call argument are emitted with the language's consume/move syntax (e.g. `std::move` in C++, `^` in Mojo).
- Adds a test verifying that a C++ `$ref` named in `:consumable-refs:` produces `std::move(...)` in the rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes `literalizer-call` rendering behavior for `$ref` arguments when the new option is used, and bumps an upstream dependency that could subtly affect generated code across languages.
> 
> **Overview**
> Adds a new `:consumable-refs:` option to the `literalizer-call` directive, letting docs mark specific `$ref` variables as *consumable* so single-use refs are emitted with the target language’s move/consume syntax (e.g. `std::move(...)` in C++).
> 
> Bumps the `literalizer` dependency to `2026.4.30.2` and wires the parsed `consumable_refs` set through to `literalize_call`, with a new integration test asserting the C++ `std::move` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e35646c4424718aa474e29d14d3411b9613726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->