### PR TITLE
Use LanguageCls.supports_module_name flag

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -200,7 +200,7 @@ def _languages_supporting_module_name() -> frozenset[str]:
     return frozenset(
         name
         for name, lang_cls in _language_types().items()
-        if "module_name" in getattr(lang_cls, "__dataclass_fields__", {})
+        if lang_cls.supports_module_name
     )
 
 


### PR DESCRIPTION
Replaces `getattr(lang_cls, "__dataclass_fields__", {})` introspection in `_languages_supporting_module_name()` with the typed `lang_cls.supports_module_name` attribute newly exposed on `LanguageCls` (literalizer 2026.4.30.2). Removes the `getattr` and the dataclass-fields fallback without adding `cast`/`type: ignore`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small logic change, but it now depends on `supports_module_name` being present/accurate in the installed `literalizer` version, which could affect compatibility and option validation.
> 
> **Overview**
> Switches `_languages_supporting_module_name()` to use the explicit `LanguageCls.supports_module_name` flag instead of introspecting `__dataclass_fields__` to decide whether a language accepts the `:module-name:` option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42cb53b85c5e3be33bd5f40c39ee42bdbe72ca70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->