### PR TITLE
Bump literalizer to 2026.4.30.3; auto-case :module-name:

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.4.30.3``.
+- New languages Tcl, Nix, SML, V, Wren, and Forth are now available via
+  the ``:language:`` option, provided by literalizer's new backends.
+- The ``:module-name:`` value is now automatically converted to the
+  case expected by the target language (e.g. ``my_module`` becomes
+  ``MyModule`` for Java, which requires PascalCase class names), using
+  the ``module_name_case`` attribute introduced in literalizer
+  ``2026.4.30.3``.
+
 2026.04.30.2
 ------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.30.2",
+    "literalizer==2026.4.30.3",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -15,10 +15,14 @@ PureScript
 Pygments
 Raku
 Roc
+SML
 SystemVerilog
+Tcl
 Vec
+Wren
 Zig
 backend
+backends
 compilable
 datetimes
 dicts

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -327,6 +327,9 @@ class _BaseLiteralizerDirective(SphinxDirective):
                     f"':module-name:'."
                 )
                 raise ExtensionError(message=msg)
+            module_name = language_cls.module_name_case.convert(
+                name=module_name,
+            )
             constructor = partial(constructor, module_name=module_name)
 
         return constructor()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5178,3 +5178,264 @@ def test_literalizer_call_consumable_refs(
     text = literal_block.astext()
     assert "std::move(my_vec)" in text
     app.cleanup()
+
+
+def test_tcl_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the tcl language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: tcl
+           :include-delimiters:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "[list" in text
+    app.cleanup()
+
+
+def test_nix_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the nix language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: nix
+           :include-delimiters:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert text.startswith("[")
+    assert "1\n  2" in text
+    app.cleanup()
+
+
+def test_sml_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the sml language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: sml
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "SInt" in text
+    app.cleanup()
+
+
+def test_v_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the V language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: v
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "1," in text
+    app.cleanup()
+
+
+def test_wren_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the wren language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: wren
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "1," in text
+    app.cleanup()
+
+
+def test_forth_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A JSON array renders correctly for the forth language."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: forth
+           :include-delimiters:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "1" in text
+    assert "2" in text
+    app.cleanup()
+
+
+def test_module_name_auto_cased(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :module-name: value is auto-converted to the language's expected
+    case using the language's module_name_case.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: java
+           :wrap-in-file:
+           :module-name: my_module
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "class MyModule" in text
+    app.cleanup()

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.30.2"
+version = "2026.4.30.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -637,9 +637,9 @@ dependencies = [
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/8c/cf4c13bbd60e4df1f23117bd2e94bb5330e32e58601b3d79c7900264caee/literalizer-2026.4.30.2.tar.gz", hash = "sha256:91269dfee8d488fcf7204841d62f10009deb86769ea233193ba02fa099777c0f", size = 1636198, upload-time = "2026-04-30T10:30:10.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/cf/8ddf057cbd64b2695d77ba80457ebc6879ca300bd9345f30cd26c893e334/literalizer-2026.4.30.3.tar.gz", hash = "sha256:a1e15a25a5b77e6cdca0a9925d8f1f0c07896378c2ab0465b9abb205a00b8124", size = 1679422, upload-time = "2026-04-30T15:02:40.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/b0/def520f98511c26abae94a6b3d06796d4d15b0cbfdf141598d6c9ab7c877/literalizer-2026.4.30.2-py3-none-any.whl", hash = "sha256:ac66bdd1c04183cc641ab3b2db25e49c8747d34a3e23a52e69c99061b162aaf9", size = 490377, upload-time = "2026-04-30T10:30:09.021Z" },
+    { url = "https://files.pythonhosted.org/packages/13/74/c967053670e2e06ae9c1da7cfaf2d2b56b8027c3378c382cc3e4cdb5ae56/literalizer-2026.4.30.3-py3-none-any.whl", hash = "sha256:a4d240028230bc734277bce223152cc2d34e9fe0c70610806170bc0c362e6669", size = 495794, upload-time = "2026-04-30T15:02:38.298Z" },
 ]
 
 [[package]]
@@ -1762,7 +1762,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.30.2" },
+    { name = "literalizer", specifier = "==2026.4.30.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.11" },


### PR DESCRIPTION
## Summary

- Bumps `literalizer` to `2026.4.30.3`, which adds backends for Tcl, Nix, SML, V, Wren, and Forth — all automatically available via `:language:` since the extension uses `ALL_LANGUAGES`.
- Uses the new `LanguageCls.module_name_case` attribute to auto-convert `:module-name:` values to the case expected by the target language (e.g. `my_module` → `MyModule` for Java).
- Adds tests for each of the six new languages and the auto-casing behaviour (116 tests total, all passing).

## Test plan

- [x] All 116 tests pass locally
- [x] Pre-commit hooks (mypy, pyright, ruff, ty, pyrefly) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped changes: a dependency bump and a straightforward transformation of `:module-name:` values, covered by new integration tests.
> 
> **Overview**
> Updates the `literalizer` dependency to `2026.4.30.3`, making new upstream backends available so `:language:` can now target **Tcl, Nix, SML, V, Wren, and Forth**.
> 
> Changes `:module-name:` handling to automatically convert the provided name into the casing required by the selected target language via `language_cls.module_name_case` (e.g. `my_module` → `MyModule` for Java).
> 
> Adds integration tests covering the six newly supported languages and the new module-name auto-casing behavior, plus updates docs/spellings and lockfiles to match the version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb02d0cc24b64c29bc060ecef7619e2883b026b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->