### PR TITLE
[codex] Bump literalizer to 2026.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.5.1``.
+- Added ``:ref-key:`` to both directives, exposing literalizer's
+  configurable reference marker key.
+- Added ``:language-version:`` to both directives, exposing each target
+  language's ``VersionFormats`` enum.
+- ``Roc`` is now selected with ``:language: roc`` while still using
+  ``text`` syntax highlighting.
+
 2026.04.30.3
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,13 +47,14 @@ Directive options
    Supported values: ``ada``, ``bash``, ``c``, ``clojure``, ``cobol``,
    ``common-lisp``, ``cpp``, ``crystal``, ``csharp``, ``d``, ``dart``,
    ``dhall``, ``elixir``, ``elm``, ``erlang``, ``fortran``, ``fsharp``,
-   ``gleam``, ``go``, ``groovy``, ``haskell``, ``hcl``, ``java``,
-   ``javascript``, ``json5``, ``jsonnet``, ``julia``, ``kotlin``, ``lua``,
-   ``matlab``, ``mojo``, ``nim``, ``norg``, ``objective-c``, ``ocaml``,
-   ``occam``, ``odin``, ``perl``, ``php``, ``powershell``, ``purescript``,
-   ``python``, ``r``, ``racket``, ``raku``, ``ruby``, ``rust``, ``scala``,
-   ``scheme``, ``swift``, ``systemverilog``, ``toml``, ``typescript``,
-   ``vb.net``, ``yaml``, ``zig``.
+   ``forth``, ``gleam``, ``go``, ``groovy``, ``haskell``, ``hcl``,
+   ``java``, ``javascript``, ``json5``, ``jsonnet``, ``julia``,
+   ``kotlin``, ``lua``, ``matlab``, ``mojo``, ``nim``, ``nix``,
+   ``norg``, ``objective-c``, ``ocaml``, ``occam``, ``odin``, ``perl``,
+   ``php``, ``powershell``, ``purescript``, ``python``, ``r``,
+   ``racket``, ``raku``, ``roc``, ``ruby``, ``rust``, ``scala``,
+   ``scheme``, ``sml``, ``swift``, ``systemverilog``, ``tcl``, ``toml``,
+   ``typescript``, ``v``, ``vb.net``, ``wren``, ``yaml``, ``zig``.
 
 ``:input-format:`` (optional)
    Input data format. If not specified, auto-detected from the file extension.
@@ -79,6 +80,32 @@ Directive options
    before the generated code.  For example, Go code will be preceded by
    ``package main``, Rust by ``use std::collections::HashMap;``, etc.
    Has no effect when the language does not require a preamble.
+
+``:language-version:`` (optional)
+   Target language version.  Values are language-specific enum member
+   names in lowercase, e.g. ``py_3_12`` for Python, ``jdk_11`` for Java,
+   and ``ada_2022`` for Ada.  Each language currently exposes one
+   default version; unsupported values raise an error.
+
+``:ref-case:`` (optional)
+   Case conversion for reference markers in the input data.  Supported
+   values: ``camel``, ``kebab``, ``pascal``, ``snake``, ``upper_snake``.
+   When set, a single-key mapping such as ``{"$ref": "user_obj"}``
+   renders as a bare identifier instead of a literal dictionary.
+
+``:ref-key:`` (optional)
+   Marker key used with ``:ref-case:`` to detect references.  Defaults
+   to ``$ref``.  For example, with ``:ref-key: $reference`` the mapping
+   ``{"$reference": "user_obj"}`` is treated as a reference marker.
+
+``:module-name:`` (optional)
+   Module or wrapper name used by languages whose ``:wrap-in-file:``
+   output introduces a named scope.  The value is converted to the case
+   expected by the selected language.
+
+``:wrap-in-file:`` (optional flag)
+   Wrap the generated code in a complete file/module when the selected
+   language supports that mode.
 
 ``:date-format:`` (optional)
    How to render YAML dates.  Not all values are valid for every
@@ -543,8 +570,9 @@ For positional-call languages like Go, the same data renders as:
 The ``literalizer-call`` directive also supports these shared options
 from the ``literalizer`` directive: ``:language:``, ``:input-format:``,
 ``:pre-indent-level:``, ``:indent:``, ``:indent-char:``,
-``:include-preamble:``, and all format options (e.g. ``:string-format:``,
-``:trailing-comma:``, etc.).
+``:include-preamble:``, ``:language-version:``, ``:ref-case:``,
+``:ref-key:``, ``:module-name:``, ``:wrap-in-file:``, and all format
+options (e.g. ``:string-format:``, ``:trailing-comma:``, etc.).
 
 
 Reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.4.30.3",
+    "literalizer==2026.5.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -34,15 +34,19 @@ from sphinx.util.docutils import SphinxDirective
 from sphinx.util.typing import ExtensionMetadata
 
 
+def _language_name(lang_cls: LanguageCls) -> str:
+    """Return the directive language key for a language class."""
+    pygments_name = lang_cls.pygments_name
+    if pygments_name is None or pygments_name == "text":
+        return lang_cls.__name__.lower()
+    return pygments_name
+
+
 @cache
 def _language_types() -> dict[str, LanguageCls]:
     """Map directive language keys to their language classes."""
     return {
-        (
-            lang_cls.__name__.lower()
-            if lang_cls.pygments_name is None
-            else lang_cls.pygments_name
-        ): lang_cls
+        _language_name(lang_cls=lang_cls): lang_cls
         for lang_cls in ALL_LANGUAGES
     }
 
@@ -70,6 +74,7 @@ _FORMAT_OPTION_GETTERS: dict[
     "string-format": lambda cls: cls.StringFormats,
     "trailing-comma": lambda cls: cls.TrailingCommas,
     "line-ending": lambda cls: cls.LineEndings,
+    "language-version": lambda cls: cls.VersionFormats,
     "empty-dict-key": lambda cls: cls.EmptyDictKey,
     "heterogeneous-strategy": lambda cls: cls.HeterogeneousStrategies,
     "call-style": lambda cls: cls.CallStyles,
@@ -189,6 +194,7 @@ _COMMON_OPTIONS: dict[str, Callable[[str], Any]] = {
         argument=x,
         values=_IDENTIFIER_CASE_VALUES,
     ),
+    "ref-key": directives.unchanged_required,
 }
 
 
@@ -367,6 +373,17 @@ class _BaseLiteralizerDirective(SphinxDirective):
         self.add_name(node=node)
         return [node]
 
+    def _resolve_ref_options(self) -> tuple[IdentifierCase | None, str]:
+        """Resolve reference marker options."""
+        ref_case_value: str | None = self.options.get("ref-case")
+        ref_case: IdentifierCase | None = (
+            None
+            if ref_case_value is None
+            else IdentifierCase[ref_case_value.upper()]
+        )
+        ref_key: str = self.options.get("ref-key", "$ref")
+        return ref_case, ref_key
+
 
 @beartype
 class LiteralizerDirective(_BaseLiteralizerDirective):
@@ -403,6 +420,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :string-format: double
            :trailing-comma: yes
            :line-ending: semicolon
+           :language-version: py_3_12
            :empty-dict-key: positional
            :heterogeneous-strategy: tagged_enum
            :default-set-element-type: String
@@ -414,6 +432,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :module-name: MyModule
            :wrap-in-file:
            :ref-case: camel
+           :ref-key: $reference
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -495,12 +514,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
                 )
 
         wrap_in_file: bool = "wrap-in-file" in self.options
-        ref_case_value: str | None = self.options.get("ref-case")
-        ref_case: IdentifierCase | None = (
-            None
-            if ref_case_value is None
-            else IdentifierCase[ref_case_value.upper()]
-        )
+        ref_case, ref_key = self._resolve_ref_options()
 
         input_format = self._resolve_input_format(data_path=data_path)
         result = literalize(
@@ -512,6 +526,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
             variable_form=variable_form,
             wrap_in_file=wrap_in_file,
             ref_case=ref_case,
+            ref_key=ref_key,
         )
         parts: list[str] = []
         if include_preamble and result.preamble:
@@ -550,6 +565,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :indent-char: spaces
            :include-preamble:
            :ref-case: camel
+           :ref-key: $reference
            :module-name: MyModule
            :consumable-refs: my_var,other_var
     """
@@ -598,12 +614,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
             call_transform = _call_transform
 
-        ref_case_value: str | None = self.options.get("ref-case")
-        ref_case: IdentifierCase | None = (
-            None
-            if ref_case_value is None
-            else IdentifierCase[ref_case_value.upper()]
-        )
+        ref_case, ref_key = self._resolve_ref_options()
 
         consumable_refs_value: str | None = self.options.get("consumable-refs")
         consumable_refs: frozenset[str] = (
@@ -628,6 +639,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                 per_element=per_element,
                 ref_case=ref_case,
                 consumable_refs=consumable_refs,
+                ref_key=ref_key,
             )
         except ParameterCountMismatchError as exc:
             msg = (

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -865,7 +865,7 @@ def test_date_format_epoch(
 
         .. code-block:: python
 
-           1705314600.0,
+           1705314600,
     """
         )
     )
@@ -5439,3 +5439,201 @@ def test_module_name_auto_cased(
     text = literal_block.astext()
     assert "class MyModule" in text
     app.cleanup()
+
+
+def test_roc_language_key(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Roc is selected by language name even though Pygments falls back
+    to text.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: roc
+           :include-delimiters:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert "RList" in text
+    assert literal_block["language"] == "text"
+    app.cleanup()
+
+
+def test_ref_key_literalizer(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :ref-key: option customizes ref markers for literalizer."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"$reference": "user_obj"}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :ref-case: snake
+           :ref-key: $reference
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == "user_obj"
+    app.cleanup()
+
+
+def test_ref_key_literalizer_call(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :ref-key: option customizes ref markers for
+    literalizer-call.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[{"$reference": "user_obj"}, 42]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: process
+           :parameter-names: user,count
+           :per-element:
+           :ref-case: snake
+           :ref-key: $reference
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == "process(user=user_obj, count=42)"
+    app.cleanup()
+
+
+def test_language_version(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :language-version: option selects a literalizer version
+    enum.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :language-version: py_3_12
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == "1,\n2,"
+    app.cleanup()
+
+
+def test_unsupported_language_version_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """An unsupported language-version raises a clear ExtensionError."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :language-version: ada_2022
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"Language 'python' does not support "
+            r"language-version 'ada_2022'\."
+        ),
+    ):
+        app.build()

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.4.30.3"
+version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -637,9 +637,9 @@ dependencies = [
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/cf/8ddf057cbd64b2695d77ba80457ebc6879ca300bd9345f30cd26c893e334/literalizer-2026.4.30.3.tar.gz", hash = "sha256:a1e15a25a5b77e6cdca0a9925d8f1f0c07896378c2ab0465b9abb205a00b8124", size = 1679422, upload-time = "2026-04-30T15:02:40.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/91/8ef9a6896ad813d82641251e0f6968784da30826a18250b05d8468c7e834/literalizer-2026.5.1.tar.gz", hash = "sha256:b0b14735a6c58a2687f5b71665fee2ac77066b276c98dba98f68d4d1e73f5402", size = 1732577, upload-time = "2026-05-01T05:10:43.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/74/c967053670e2e06ae9c1da7cfaf2d2b56b8027c3378c382cc3e4cdb5ae56/literalizer-2026.4.30.3-py3-none-any.whl", hash = "sha256:a4d240028230bc734277bce223152cc2d34e9fe0c70610806170bc0c362e6669", size = 495794, upload-time = "2026-04-30T15:02:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cb/eb96d4c8d721d1a3ac6c287bc29272e36a8f3c3270cdf09e1cf2d0268b6d/literalizer-2026.5.1-py3-none-any.whl", hash = "sha256:ef2cff0982ec8c2d063b92ec798967d800a67dfa2357c64b223ba61edefe6dae", size = 501912, upload-time = "2026-05-01T05:10:41.265Z" },
 ]
 
 [[package]]
@@ -1762,7 +1762,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.4.30.3" },
+    { name = "literalizer", specifier = "==2026.5.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.11" },


### PR DESCRIPTION
Bumps literalizer to 2026.5.1 and exposes the new ref-key and language-version options on both directives.
It also maps text-highlighted languages such as Roc by class name so users can select :language: roc, updates documentation and changelog entries, and adjusts tests for the upstream epoch rendering change.
Validated with pytest, Ruff, mypy, pyright, Sphinx HTML build, and the push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: updates a core rendering dependency and expands directive option parsing, which could change generated output and error handling across many languages.
> 
> **Overview**
> Updates the extension to `literalizer==2026.5.1` and aligns docs/lockfiles/changelog with the new release.
> 
> Exposes new directive options `:language-version:` (mapped to each language’s `VersionFormats`) and `:ref-key:` (custom ref marker key) for both `literalizer` and `literalizer-call`, wiring them through to `literalize`/`literalize_call`.
> 
> Adjusts language key resolution so languages with `pygments_name == "text"` (notably `Roc`) are selectable via `:language: roc` while still using `text` highlighting, and updates/expands tests to cover the new options and an upstream epoch rendering change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ea9241e57c01ae9820ed25306f01c6e769f9f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->