### PR TITLE
[codex] Add omit-code for literalizer-call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- Added ``:omit-code:`` to ``literalizer-call`` so callers can combine it
+  with ``:include-preamble:`` to render imports or other preamble lines
+  without also rendering generated calls.
+
 2026.05.01
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -567,6 +567,12 @@ For positional-call languages like Go, the same data renders as:
    call.  Without this flag, the whole literalized value is passed as a
    single argument.
 
+``:omit-code:`` (optional flag)
+   Omit the generated call expressions.  Combine this with
+   ``:include-preamble:`` to render only imports or other preamble lines,
+   which is useful when a later ``literalizer-call`` block needs preamble
+   lines at the top of a combined snippet.
+
 The ``literalizer-call`` directive also supports these shared options
 from the ``literalizer`` directive: ``:language:``, ``:input-format:``,
 ``:pre-indent-level:``, ``:indent:``, ``:indent-char:``,

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -564,6 +564,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :indent: 4
            :indent-char: spaces
            :include-preamble:
+           :omit-code:
            :ref-case: camel
            :ref-key: $reference
            :module-name: MyModule
@@ -577,6 +578,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         "per-element": directives.flag,
         "call-transform": directives.unchanged_required,
         "consumable-refs": directives.unchanged,
+        "omit-code": directives.flag,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -595,6 +597,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
         pre_indent_level: int = self.options.get("pre-indent-level", 0)
         include_preamble: bool = "include-preamble" in self.options
+        omit_code: bool = "omit-code" in self.options
         target_function: str = self.options["target-function"]
         parameter_names = [
             p.strip() for p in self.options["parameter-names"].split(",")
@@ -658,7 +661,8 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         parts: list[str] = []
         if include_preamble and result.preamble:
             parts.append("\n".join(result.preamble))
-        parts.append(code)
+        if not omit_code:
+            parts.append(code)
         text = "\n\n".join(parts)
 
         return self._make_node(

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4348,6 +4348,52 @@ def test_literalizer_call_include_preamble(
     app.cleanup()
 
 
+def test_literalizer_call_omit_code(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :omit-code: option omits generated calls."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(
+        data="- 2024-01-15T10:30:00Z\n",
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.yaml
+           :language: java
+           :target-function: billingSystem.recordDelivery
+           :parameter-names: delivered_at
+           :per-element:
+           :datetime-format: instant
+           :include-preamble:
+           :omit-code:
+    """
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    literal_blocks = list(
+        doctree.findall(condition=nodes.literal_block),
+    )
+    (literal_block,) = literal_blocks
+    assert literal_block.astext() == "import java.time.Instant;"
+    app.cleanup()
+
+
 def test_literalizer_call_source_is_absolute(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Adds `:omit-code:` to `literalizer-call` so generated calls can be suppressed while `:include-preamble:` still emits imports and other preamble lines. This fixes awkward combined snippets where a later call block needs its preamble hoisted before earlier setup calls. Includes regression coverage for Java instant datetime imports and updates the docs and changelog. Closes #171.

Validation: pre-commit hooks during commit, push-time type checks, and `uv run --extra dev pytest tests/test_extension.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional flag to suppress emitted call code while leaving preamble behavior intact, with a targeted regression test and docs updates.
> 
> **Overview**
> Adds a new `:omit-code:` flag to the `literalizer-call` directive so callers can render only the language preamble (e.g., imports) while suppressing generated call expressions.
> 
> Updates the docs and changelog to describe the new option, and adds a regression test asserting that `:include-preamble:` + `:omit-code:` for Java `instant` datetimes outputs only `import java.time.Instant;`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5e90e344a850fa4cec2e654dc582b5dc4f25f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->