### PR TITLE
Bump literalizer and expose collection layout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.5.1.1``.
+- Added ``:collection-layout:`` to both directives, exposing
+  literalizer's nested collection layout control.
+- Go output now follows literalizer's idiomatic no-semicolon default
+  line ending unless ``:line-ending: semicolon`` is selected.
+
 2026.05.01.1
 ------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,6 +75,15 @@ Directive options
    Include collection delimiters in the output
    (``[`` … ``]`` for arrays, ``{`` … ``}`` for dicts).
 
+``:collection-layout:`` (optional)
+   How to render collections nested inside other collections.
+   Supported values:
+
+   ``compact``
+      Keep nested collections on one line (default).
+   ``multiline``
+      Render non-empty nested collections with one element per line.
+
 ``:include-preamble:`` (optional flag)
    Include language preamble lines (imports, package declarations, etc.)
    before the generated code.  For example, Go code will be preceded by
@@ -417,13 +426,15 @@ Directive options
       Racket, TOML, Visual Basic, YAML.
 
 ``:line-ending:`` (optional)
-   Whether to include semicolons at the end of statements.
+   Whether to include semicolons at the end of statements.  The default
+   depends on the selected language; for example, Go defaults to
+   ``none``.
    Supported values:
 
    ``semicolon``
-      Include semicolons.  This is the default for all languages.
+      Include semicolons where supported.
    ``none``
-      Omit semicolons.  Available for JavaScript, TypeScript.
+      Omit semicolons.  Available for Go, JavaScript, TypeScript.
 
 ``:empty-dict-key:`` (optional)
    How to handle empty string keys in dictionaries.
@@ -577,8 +588,9 @@ The ``literalizer-call`` directive also supports these shared options
 from the ``literalizer`` directive: ``:language:``, ``:input-format:``,
 ``:pre-indent-level:``, ``:indent:``, ``:indent-char:``,
 ``:include-preamble:``, ``:language-version:``, ``:ref-case:``,
-``:ref-key:``, ``:module-name:``, ``:wrap-in-file:``, and all format
-options (e.g. ``:string-format:``, ``:trailing-comma:``, etc.).
+``:ref-key:``, ``:module-name:``, ``:wrap-in-file:``,
+``:collection-layout:``, and all format options (e.g.
+``:string-format:``, ``:trailing-comma:``, etc.).
 
 
 Reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.1",
+    "literalizer==2026.5.1.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -16,6 +16,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from literalizer import (
     BothVariableForms,
+    CollectionLayout,
     ExistingVariable,
     IdentifierCase,
     InputFormat,
@@ -83,6 +84,9 @@ _FORMAT_OPTION_GETTERS: dict[
 
 _IDENTIFIER_CASE_VALUES: tuple[str, ...] = tuple(
     sorted(m.name.lower() for m in IdentifierCase)
+)
+_COLLECTION_LAYOUT_VALUES: tuple[str, ...] = tuple(
+    sorted(m.name.lower() for m in CollectionLayout)
 )
 
 
@@ -195,6 +199,10 @@ _COMMON_OPTIONS: dict[str, Callable[[str], Any]] = {
         values=_IDENTIFIER_CASE_VALUES,
     ),
     "ref-key": directives.unchanged_required,
+    "collection-layout": lambda x: directives.choice(
+        argument=x,
+        values=_COLLECTION_LAYOUT_VALUES,
+    ),
 }
 
 
@@ -384,6 +392,14 @@ class _BaseLiteralizerDirective(SphinxDirective):
         ref_key: str = self.options.get("ref-key", "$ref")
         return ref_case, ref_key
 
+    def _resolve_collection_layout(self) -> CollectionLayout:
+        """Resolve the nested collection layout option."""
+        collection_layout_value: str = self.options.get(
+            "collection-layout",
+            "compact",
+        )
+        return CollectionLayout[collection_layout_value.upper()]
+
 
 @beartype
 class LiteralizerDirective(_BaseLiteralizerDirective):
@@ -433,6 +449,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :wrap-in-file:
            :ref-case: camel
            :ref-key: $reference
+           :collection-layout: multiline
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -515,6 +532,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
 
         wrap_in_file: bool = "wrap-in-file" in self.options
         ref_case, ref_key = self._resolve_ref_options()
+        collection_layout = self._resolve_collection_layout()
 
         input_format = self._resolve_input_format(data_path=data_path)
         result = literalize(
@@ -527,6 +545,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
             wrap_in_file=wrap_in_file,
             ref_case=ref_case,
             ref_key=ref_key,
+            collection_layout=collection_layout,
         )
         parts: list[str] = []
         if include_preamble and result.preamble:
@@ -569,6 +588,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :ref-key: $reference
            :module-name: MyModule
            :consumable-refs: my_var,other_var
+           :collection-layout: multiline
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -618,6 +638,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             call_transform = _call_transform
 
         ref_case, ref_key = self._resolve_ref_options()
+        collection_layout = self._resolve_collection_layout()
 
         consumable_refs_value: str | None = self.options.get("consumable-refs")
         consumable_refs: frozenset[str] = (
@@ -643,6 +664,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                 ref_case=ref_case,
                 consumable_refs=consumable_refs,
                 ref_key=ref_key,
+                collection_layout=collection_layout,
             )
         except ParameterCountMismatchError as exc:
             msg = (

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3108,6 +3108,149 @@ def test_line_ending_none(
     assert semi_html != none_html
 
 
+def test_go_line_ending_defaults_to_none(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Go uses its idiomatic no-semicolon default line ending."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"key": "value"}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: go
+           :include-delimiters:
+           :variable-name: x
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        'x := map[string]string{\n\t"key": "value",\n}'
+    )
+    app.cleanup()
+
+
+def test_collection_layout_literalizer_multiline(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :collection-layout: option controls nested literal layout."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1, 2], [3, 4]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :include-delimiters:
+           :collection-layout: multiline
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        "(\n"
+        "    (\n"
+        "        1,\n"
+        "        2,\n"
+        "    ),\n"
+        "    (\n"
+        "        3,\n"
+        "        4,\n"
+        "    ),\n"
+        ")"
+    )
+    app.cleanup()
+
+
+def test_collection_layout_literalizer_call_multiline(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :collection-layout: option applies inside call arguments."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[[[1, 2], [3, 4]]]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: handle
+           :parameter-names: items
+           :per-element:
+           :collection-layout: multiline
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        "handle(items=(\n"
+        "    (\n"
+        "        1,\n"
+        "        2,\n"
+        "    ),\n"
+        "    (\n"
+        "        3,\n"
+        "        4,\n"
+        "    ),\n"
+        "))"
+    )
+    app.cleanup()
+
+
 def test_empty_dict_key_error(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.1"
+version = "2026.5.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -637,9 +637,9 @@ dependencies = [
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/91/8ef9a6896ad813d82641251e0f6968784da30826a18250b05d8468c7e834/literalizer-2026.5.1.tar.gz", hash = "sha256:b0b14735a6c58a2687f5b71665fee2ac77066b276c98dba98f68d4d1e73f5402", size = 1732577, upload-time = "2026-05-01T05:10:43.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/27/f6bc09b4e9f5db3d76c4857887366827460b916ad839048a8eb57defa43a/literalizer-2026.5.1.1.tar.gz", hash = "sha256:edc4deb52a4f901901000b906cef899b58569f009e8099ec633114418c616303", size = 1788992, upload-time = "2026-05-01T09:34:36.539Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/cb/eb96d4c8d721d1a3ac6c287bc29272e36a8f3c3270cdf09e1cf2d0268b6d/literalizer-2026.5.1-py3-none-any.whl", hash = "sha256:ef2cff0982ec8c2d063b92ec798967d800a67dfa2357c64b223ba61edefe6dae", size = 501912, upload-time = "2026-05-01T05:10:41.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ba/1601284678763bf6bd4300dbfde73c39cd2a1455345c21a6b28569632fb6/literalizer-2026.5.1.1-py3-none-any.whl", hash = "sha256:a9910f4635e6c7404f62fedbf9dfc4c1c1faa458e4352a0a6490f0c9751bfda8", size = 503690, upload-time = "2026-05-01T09:34:34.874Z" },
 ]
 
 [[package]]
@@ -1762,7 +1762,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.1" },
+    { name = "literalizer", specifier = "==2026.5.1.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.20.2" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.11" },


### PR DESCRIPTION
Bumps literalizer to 2026.5.1.1 and updates the lockfile.

Exposes literalizer's new nested collection layout control as `:collection-layout:` on both directives, with docs and Sphinx coverage for literal output and call arguments.

Documents and tests the updated Go default line-ending behavior, where Go now omits semicolons unless explicitly requested.

Validation: full extension pytest file, Ruff, mypy, docs build, and push hooks all passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rendered code output (notably Go semicolon defaults) and adds a new formatting option, which may alter existing documentation snippets and tests after the `literalizer` dependency bump.
> 
> **Overview**
> Bumps the `literalizer` dependency to `2026.5.1.1` (including lockfile updates) and documents the resulting behavior changes.
> 
> Exposes literalizer’s nested collection formatting as a new `:collection-layout:` option on both `literalizer` and `literalizer-call`, wiring it through to `literalize`/`literalize_call` and adding integration tests for multiline nested output.
> 
> Updates docs/tests to reflect that Go now defaults to *no* semicolon line endings unless `:line-ending: semicolon` is explicitly selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a11b459e9fc3738e7555d29d935d7872d7791df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->