### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --jobs 4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -155,7 +155,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          --jobs 4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy --jobs 4
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -156,7 +156,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          --jobs 4"
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]


### PR DESCRIPTION
## Summary
- Run `mypy` pre-push hook with 4 parallel workers via `--jobs 4`.
- Update `mypy-docs` doccmd invocation to pass `mypy --jobs 4` through the `--command` string.
- Keep existing hook behavior unchanged apart from faster parallel type checking.

## Test plan
- [x] Run `git commit` and verify pre-commit hooks pass.
- [ ] Run `pre-commit run mypy --all-files`.
- [ ] Run `pre-commit run mypy-docs --all-files`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tweaks pre-push hook commands to speed up type checking; no runtime code or behavior changes beyond mypy invocation.
> 
> **Overview**
> Speeds up pre-push type checking by running `mypy` with `--num-workers=4` in the `mypy` pre-commit hook.
> 
> Updates the `mypy-docs` hook to pass the same `--num-workers=4` option through its `doccmd --command` string so docs type checks run in parallel as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371668c4c93455ebe58ce0169b415c0ffcf62cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->