### PR TITLE
Bump literalizer to 2026.5.14 and wire variable_form into literalizer-call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,17 @@ Changelog
 Next
 ----
 
-- Bumped ``literalizer`` to ``2026.5.13.1``.
+- Bumped ``literalizer`` to ``2026.5.14``.
+- The ``literalizer-call`` directive now accepts ``:variable-name:``,
+  ``:existing-variable:``, and ``:modifiers:`` options, wrapping the
+  rendered call in an idiomatic per-language variable binding (e.g.
+  ``let my_data = make_widget(42);``).  ``:both-variable-forms:`` is
+  not supported for ``literalizer-call`` because emitting both a
+  declaration and an assignment would invoke the target function
+  twice; upstream ``literalizer`` raises
+  ``UnsupportedCallShapeError`` for languages whose call form is a
+  statement rather than an expression, or whose declaration template
+  is only valid for literal values.
 - Removed the ``:line-ending:`` directive option.  Upstream
   ``literalizer`` removed the corresponding ``LineEndings`` enum;
   statement terminators now follow each language's idiomatic default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.13.1",
+    "literalizer==2026.5.14",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -431,6 +431,64 @@ class _BaseLiteralizerDirective(SphinxDirective):
         ref_key: str = self.options.get("ref-key", "$ref")
         return ref_case, ref_key
 
+    def _resolve_variable_form(
+        self,
+        language_name: str,
+        language_cls: LanguageCls,
+        *,
+        allow_both: bool,
+    ) -> VariableForm | None:
+        """Resolve the variable-form options into a ``VariableForm``."""
+        variable_name: str | None = self.options.get("variable-name")
+        existing_variable: bool = "existing-variable" in self.options
+        both_variable_forms: bool = (
+            allow_both and "both-variable-forms" in self.options
+        )
+        modifiers_value: str | None = self.options.get("modifiers")
+
+        if modifiers_value is not None and variable_name is None:
+            msg = "':modifiers:' requires ':variable-name:'."
+            raise ExtensionError(message=msg)
+        if modifiers_value is not None and existing_variable:
+            msg = (
+                "':modifiers:' cannot be combined with ':existing-variable:'."
+            )
+            raise ExtensionError(message=msg)
+        if modifiers_value is not None and both_variable_forms:
+            msg = (
+                "':modifiers:' cannot be combined with "
+                "':both-variable-forms:'."
+            )
+            raise ExtensionError(message=msg)
+        if both_variable_forms and variable_name is None:
+            msg = "':both-variable-forms:' requires ':variable-name:'."
+            raise ExtensionError(message=msg)
+        if both_variable_forms and existing_variable:
+            msg = (
+                "':both-variable-forms:' cannot be combined with "
+                "':existing-variable:'."
+            )
+            raise ExtensionError(message=msg)
+
+        if variable_name is None:
+            return None
+
+        modifiers: frozenset[enum.Enum] = (
+            frozenset()
+            if modifiers_value is None
+            else _parse_modifiers(
+                language_name=language_name,
+                language_cls=language_cls,
+                value=modifiers_value,
+            )
+        )
+
+        if existing_variable:
+            return ExistingVariable(name=variable_name)
+        if both_variable_forms:
+            return BothVariableForms(name=variable_name, modifiers=modifiers)
+        return NewVariable(name=variable_name, modifiers=modifiers)
+
     def _resolve_collection_layout(self) -> CollectionLayout:
         """Resolve the nested collection layout option."""
         collection_layout_value: str = self.options.get(
@@ -499,60 +557,6 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         "modifiers": directives.unchanged,
     }
 
-    def _resolve_variable_form(
-        self,
-        language_name: str,
-        language_cls: LanguageCls,
-    ) -> VariableForm | None:
-        """Resolve the variable-form options into a ``VariableForm``."""
-        variable_name: str | None = self.options.get("variable-name")
-        existing_variable: bool = "existing-variable" in self.options
-        both_variable_forms: bool = "both-variable-forms" in self.options
-        modifiers_value: str | None = self.options.get("modifiers")
-
-        if modifiers_value is not None and variable_name is None:
-            msg = "':modifiers:' requires ':variable-name:'."
-            raise ExtensionError(message=msg)
-        if modifiers_value is not None and existing_variable:
-            msg = (
-                "':modifiers:' cannot be combined with ':existing-variable:'."
-            )
-            raise ExtensionError(message=msg)
-        if modifiers_value is not None and both_variable_forms:
-            msg = (
-                "':modifiers:' cannot be combined with "
-                "':both-variable-forms:'."
-            )
-            raise ExtensionError(message=msg)
-        if both_variable_forms and variable_name is None:
-            msg = "':both-variable-forms:' requires ':variable-name:'."
-            raise ExtensionError(message=msg)
-        if both_variable_forms and existing_variable:
-            msg = (
-                "':both-variable-forms:' cannot be combined with "
-                "':existing-variable:'."
-            )
-            raise ExtensionError(message=msg)
-
-        if variable_name is None:
-            return None
-
-        modifiers: frozenset[enum.Enum] = (
-            frozenset()
-            if modifiers_value is None
-            else _parse_modifiers(
-                language_name=language_name,
-                language_cls=language_cls,
-                value=modifiers_value,
-            )
-        )
-
-        if existing_variable:
-            return ExistingVariable(name=variable_name)
-        if both_variable_forms:
-            return BothVariableForms(name=variable_name, modifiers=modifiers)
-        return NewVariable(name=variable_name, modifiers=modifiers)
-
     def run(self) -> list[nodes.Node]:
         """Read the data file and produce a literal block."""
         env = self.state.document.settings.env
@@ -573,6 +577,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         variable_form = self._resolve_variable_form(
             language_name=language_name,
             language_cls=language_cls,
+            allow_both=True,
         )
         wrap_in_file: bool = "wrap-in-file" in self.options
         ref_case, ref_key = self._resolve_ref_options()
@@ -634,6 +639,9 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :module-name: MyModule
            :consumable-refs: my_var,other_var
            :collection-layout: multiline
+           :variable-name: my_data
+           :existing-variable:
+           :modifiers: public,static
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -644,6 +652,9 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         "call-transform": directives.unchanged_required,
         "consumable-refs": directives.unchanged,
         "omit-code": directives.flag,
+        "variable-name": directives.unchanged,
+        "existing-variable": directives.flag,
+        "modifiers": directives.unchanged,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -684,6 +695,11 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
         ref_case, ref_key = self._resolve_ref_options()
         collection_layout = self._resolve_collection_layout()
+        variable_form = self._resolve_variable_form(
+            language_name=language_name,
+            language_cls=language_cls,
+            allow_both=False,
+        )
 
         consumable_refs_value: str | None = self.options.get("consumable-refs")
         consumable_refs: frozenset[str] = (
@@ -711,6 +727,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                     consumable_refs=consumable_refs,
                     ref_key=ref_key,
                     collection_layout=collection_layout,
+                    variable_form=variable_form,
                 )
         except ParameterCountMismatchError as exc:
             msg = (

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5307,6 +5307,134 @@ def test_literalizer_call_consumable_refs(
     app.cleanup()
 
 
+def test_literalizer_call_variable_name_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:variable-name:`` wraps the ``literalizer-call`` output in a
+    per-language variable binding.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"count": 42}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: rust
+           :target-function: make_widget
+           :parameter-names: count
+           :variable-name: my_data
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    expected = 'let my_data = make_widget(HashMap::from([("count", 42)]));'
+    assert text == expected
+    app.cleanup()
+
+
+def test_literalizer_call_existing_variable_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:existing-variable:`` produces an assignment without a
+    declaration keyword.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"count": 42}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: rust
+           :target-function: make_widget
+           :parameter-names: count
+           :variable-name: my_data
+           :existing-variable:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    expected = 'my_data = make_widget(HashMap::from([("count", 42)]));'
+    assert text == expected
+    app.cleanup()
+
+
+def test_literalizer_call_variable_form_per_element_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:variable-name:`` with ``:per-element:`` surfaces literalizer's
+    ``UnsupportedCallShapeError`` as an ``ExtensionError``.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"count": 42}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: rust
+           :target-function: make_widget
+           :parameter-names: count
+           :per-element:
+           :variable-name: my_data
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(expected_exception=ExtensionError):
+        app.build()
+    app.cleanup()
+
+
 def test_tcl_language(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.13.1"
+version = "2026.5.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -674,10 +674,11 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/cf/c7eb11e5ea724361cfa0d0e91e33b7975309f78827dca5d27219a6ce239c/literalizer-2026.5.13.1.tar.gz", hash = "sha256:2ee8d970e88b991b75bd769374ecbbd2771b5b8ddd32674f2ff8ee2736ff9db4", size = 2057844, upload-time = "2026-05-13T11:29:58.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/37/1212e92f23bcc744a1e826e1f4b848195b4c673f414a94caf9ac6a55dc91/literalizer-2026.5.14.tar.gz", hash = "sha256:23ab68bc619677803e0df0b0c887b648fb348adfedb4f8e6da96dcee7bff8cfe", size = 2105743, upload-time = "2026-05-14T07:50:01.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/67/4211c4292d49525b313ceece2f35f8200419980f191d36dffb7d5c139aee/literalizer-2026.5.13.1-py3-none-any.whl", hash = "sha256:b3d05fba6fb2f3460a135e7cf0487adf95f3a0e96e4842a7fc4d46d3e33aa853", size = 544758, upload-time = "2026-05-13T11:29:56.771Z" },
+    { url = "https://files.pythonhosted.org/packages/79/1e/2e4f6a821961f4106d93430e47621b45fabf0c358e9eadb868c9dda13c85/literalizer-2026.5.14-py3-none-any.whl", hash = "sha256:24d8b5abc13a84b11af1c0b8c12d37dde7018fdf423627f9cc378f89078e7828", size = 558059, upload-time = "2026-05-14T07:49:59.157Z" },
 ]
 
 [[package]]
@@ -1727,9 +1728,16 @@ wheels = [
 
 [[package]]
 name = "shfmt-py"
-version = "3.12.0.2"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/d9/a1ea26749bd19467e9fbfe7b34e6c8df517e01de4028a45b954eebe8c03b/shfmt_py-3.12.0.2.tar.gz", hash = "sha256:6a0dc675b37d000eb236609cf15aedd9e7a538927ea02c57b617908b6f237e9c", size = 4467, upload-time = "2025-07-08T06:54:40.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/d5/c2ad5c6593a34da7344cf39bde65763e8cda752589074ba1619e55b317ad/shfmt_py-4.0.0.tar.gz", hash = "sha256:1e5fdacf40aabaa77a97639d52a6220df0893b46658d82b7f136f4e66e2b2fb0", size = 11947, upload-time = "2026-05-13T09:25:50.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/1d/8f72824e2a0e06dc0bc2687baacaba0573be7d2e93c01d1e895fddd8c13e/shfmt_py-4.0.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:75a4919a03fb3bcff9795e3cc7b971e37e74905654d2f11605001cab42e5f92f", size = 1343695, upload-time = "2026-05-13T09:25:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/82/9564a2c2a76fbec94db1b3a3c37a9a1d00e7eafca2cdd2e0d19082618d7e/shfmt_py-4.0.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:bb3d236163ff39c7790953e069938caf247e7646399f7a059f00f65d4e6916d6", size = 1237947, upload-time = "2026-05-13T09:25:44.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a9/6fce944efa530db941edd11388d70dc7384aaf12169a3b0847b6a6c987b0/shfmt_py-4.0.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:4701336c3cb5f3959a5e85481b14f02054ea094b3c666f3d04649bbe10de3c25", size = 1218771, upload-time = "2026-05-13T09:25:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/64/43/e3965a25bb39555f2791c6860214f62b6f976f9ac7e9786073364bcdd9a6/shfmt_py-4.0.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:e57877abe0177a9da7bbb5390fe7e96aa19b00958189a025634039aef8834d44", size = 1350939, upload-time = "2026-05-13T09:25:47.584Z" },
+    { url = "https://files.pythonhosted.org/packages/95/20/db2430d9262d2cffadcad2b330441e13031f1ab849ec069659edb7f23257/shfmt_py-4.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:bd4f3d36264d4ba8b014ff73e5e702aaa2345845c021f563480128de3705135b", size = 1427721, upload-time = "2026-05-13T09:25:48.865Z" },
+]
 
 [[package]]
 name = "snowballstemmer"
@@ -1876,7 +1884,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.13.1" },
+    { name = "literalizer", specifier = "==2026.5.14" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.3.13" },
@@ -1891,7 +1899,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
-    { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==3.12.0.2" },
+    { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==4.0.0" },
     { name = "sphinx", specifier = ">=7.0" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = "==9.1.0" },
     { name = "sphinx-copybutton", marker = "extra == 'dev'", specifier = "==0.5.2" },


### PR DESCRIPTION
## Summary
- Bumps the `literalizer` pin from `2026.5.13.1` to `2026.5.14`.
- Adds `:variable-name:`, `:existing-variable:`, and `:modifiers:` options to the `literalizer-call` directive, exposing 2026.5.14's new `variable_form` so calls render as idiomatic per-language variable bindings (e.g. `let my_data = make_widget(...)`).
- Shares `_resolve_variable_form` between the two directives via the base class; `:both-variable-forms:` stays exclusive to `literalizer` since literalizer itself rejects it for calls.

## Test plan
- [x] `pytest tests/` (128 passed, including three new tests covering `NewVariable`, `ExistingVariable`, and the `:per-element:` incompatibility surfaced as `ExtensionError`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes code generation behavior for `literalizer-call` and updates a pinned dependency, which can affect rendered docs/output across languages.
> 
> **Overview**
> Bumps the pinned `literalizer` dependency to `2026.5.14` (and updates lockfiles/changelog accordingly).
> 
> Extends `literalizer-call` to accept `:variable-name:`, `:existing-variable:`, and `:modifiers:` and forwards the resolved `variable_form` into `literalize_call`, enabling idiomatic per-language variable bindings instead of bare call statements.
> 
> Refactors variable-form option parsing into `_BaseLiteralizerDirective._resolve_variable_form(allow_both=...)` so `literalizer` can still use `:both-variable-forms:` while `literalizer-call` explicitly disallows it, and adds integration tests covering new/existing variable call bindings and the `:per-element:` incompatibility surfacing as `ExtensionError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e9188dfc573fceb4a7f2ffe9bbc9ae4f483614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->