### PR TITLE
Bump literalizer to 2026.5.15.2 and adopt new APIs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,29 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.5.15.2``.
+- The ``literalizer-call`` directive gains ``:zip-file:`` and
+  ``:zip-input-format:`` options.  The data file's top-level elements
+  pair positionally with the generated calls and are exposed to
+  ``:call-transform:`` as ``$zipped``, rendered as a native literal --
+  useful for generating assertions from a parallel file of expected
+  results (e.g. ``:call-transform: assert $call == $zipped``).  This
+  follows upstream ``literalizer`` replacing ``zip_values`` with the
+  ``zip_source`` / ``zip_input_format`` pair.
+- The ``:call-transform:`` template now also substitutes ``$call`` (an
+  alias of the existing ``$0``) for the rendered call expression and
+  ``$index`` for the zero-based call position, following upstream
+  ``literalizer`` passing a ``CallContext`` to ``call_transform``
+  instead of a bare string.
+- ``CallsNotSupportedByLanguageError``, ``CallsNotSupportedByToolError``,
+  ``PerElementNotListError``, ``ZipSourceWithoutInputFormatError``, and
+  ``ZipValuesLengthMismatchError`` from ``literalizer`` are now surfaced
+  as Sphinx ``ExtensionError`` rather than an uncaught traceback.
+- The ``:heterogeneous-strategy:`` option now accepts ``record`` for
+  ``java`` and ``kotlin`` and ``tuple`` for ``rust``, and
+  ``:language-version:`` accepts ``jdk_16`` for ``java``, matching
+  upstream ``literalizer`` additions.
+
 2026.05.15
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -579,6 +579,27 @@ For positional-call languages like Go, the same data renders as:
    which is useful when a later ``literalizer-call`` block needs preamble
    lines at the top of a combined snippet.
 
+``:call-transform:`` (optional)
+   A template applied to each generated call.  These placeholders are
+   substituted: ``$call`` (and the ``$0`` alias) for the rendered call
+   expression, ``$index`` for the zero-based call position, and
+   ``$zipped`` for the matching ``:zip-file:`` element rendered as a
+   native literal (empty when no ``:zip-file:`` is given).  For example,
+   ``:call-transform: result_$index = $call``.
+
+``:zip-file:`` (optional)
+   A data file whose top-level elements pair positionally with the
+   generated calls.  Each paired element is rendered as a native literal
+   and made available to ``:call-transform:`` as ``$zipped``, which is
+   handy for generating assertions from a parallel file of expected
+   results (e.g. ``:call-transform: assert $call == $zipped``).  The
+   file is parsed with the same parser as the main source.
+
+``:zip-input-format:`` (optional)
+   The input format (``json``, ``json5``, ``yaml``, or ``toml``) of the
+   ``:zip-file:``.  Defaults to the format inferred from the
+   ``:zip-file:`` extension.
+
 The ``literalizer-call`` directive also supports these shared options
 from the ``literalizer`` directive: ``:language:``, ``:input-format:``,
 ``:pre-indent-level:``, ``:indent:``, ``:indent-char:``,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.15",
+    "literalizer==2026.5.15.2",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -17,6 +17,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from literalizer import (
     BothVariableForms,
+    CallContext,
     CollectionLayout,
     ExistingVariable,
     IdentifierCase,
@@ -30,16 +31,19 @@ from literalizer import (
 )
 from literalizer.exceptions import (
     CallArgNotSupportedError,
-    DottedCallStubNotSupportedError,
+    CallsNotSupportedByLanguageError,
+    CallsNotSupportedByToolError,
     DottedCallTargetNotSupportedError,
-    FreeFunctionCallNotSupportedError,
     ParameterCountMismatchError,
+    PerElementNotListError,
     UnrepresentableInputError,
     UnsupportedCallShapeError,
     UnsupportedIdentifierCaseError,
     VariableNameNotSupportedError,
     WrapCombinedInFileNotSupportedError,
     WrapInFileWithoutVariableNotSupportedError,
+    ZipSourceWithoutInputFormatError,
+    ZipValuesLengthMismatchError,
 )
 from literalizer.languages import ALL_LANGUAGES
 from sphinx.application import Sphinx
@@ -245,15 +249,18 @@ _EXTENSION_TO_INPUT_FORMAT: dict[str, InputFormat] = {
 # offending directive and continue under ``-W``.
 _USER_FACING_LITERALIZER_ERRORS: tuple[type[Exception], ...] = (
     CallArgNotSupportedError,
-    DottedCallStubNotSupportedError,
+    CallsNotSupportedByLanguageError,
+    CallsNotSupportedByToolError,
     DottedCallTargetNotSupportedError,
-    FreeFunctionCallNotSupportedError,
+    PerElementNotListError,
     UnrepresentableInputError,
     UnsupportedCallShapeError,
     UnsupportedIdentifierCaseError,
     VariableNameNotSupportedError,
     WrapCombinedInFileNotSupportedError,
     WrapInFileWithoutVariableNotSupportedError,
+    ZipSourceWithoutInputFormatError,
+    ZipValuesLengthMismatchError,
 )
 
 
@@ -389,11 +396,16 @@ class _BaseLiteralizerDirective(SphinxDirective):
 
         return constructor()
 
-    def _resolve_input_format(self, data_path: Path) -> InputFormat:
-        """Determine the input format from the option or file
+    def _resolve_format(
+        self,
+        data_path: Path,
+        *,
+        option_name: str,
+    ) -> InputFormat:
+        """Determine an input format from *option_name* or the file
         extension.
         """
-        explicit = self.options.get("input-format")
+        explicit = self.options.get(option_name)
         if explicit is not None:
             return InputFormat[explicit.upper()]
         suffix = data_path.suffix.lower()
@@ -402,9 +414,18 @@ class _BaseLiteralizerDirective(SphinxDirective):
         except KeyError:
             msg = (
                 f"Cannot determine input format for '{data_path.name}'. "
-                f"Use the :input-format: option."
+                f"Use the :{option_name}: option."
             )
             raise ExtensionError(message=msg) from None
+
+    def _resolve_input_format(self, data_path: Path) -> InputFormat:
+        """Determine the input format from the option or file
+        extension.
+        """
+        return self._resolve_format(
+            data_path=data_path,
+            option_name="input-format",
+        )
 
     def _make_node(
         self,
@@ -630,7 +651,9 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :parameter-names: flag,count,name
            :per-element:
            :call-style: keyword
-           :call-transform: print($0)
+           :call-transform: print($call)  # $call ($0), $index, $zipped
+           :zip-file: expected.json
+           :zip-input-format: json
            :input-format: json
            :indent: 4
            :indent-char: spaces
@@ -644,6 +667,12 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :variable-name: my_data
            :existing-variable:
            :modifiers: public,static
+
+    ``:call-transform:`` substitutes these placeholders in the template:
+    ``$call`` (and the ``$0`` alias) for the rendered call expression,
+    ``$index`` for the zero-based call position, and ``$zipped`` for the
+    matching ``:zip-file:`` element rendered as a native literal (empty
+    when no ``:zip-file:`` is given).
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -652,12 +681,60 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         "parameter-names": directives.unchanged_required,
         "per-element": directives.flag,
         "call-transform": directives.unchanged_required,
+        "zip-file": directives.unchanged_required,
+        "zip-input-format": lambda x: directives.choice(
+            argument=x,
+            values=("json", "json5", "yaml", "toml"),
+        ),
         "consumable-refs": directives.unchanged,
         "omit-code": directives.flag,
         "variable-name": directives.unchanged,
         "existing-variable": directives.flag,
         "modifiers": directives.unchanged,
     }
+
+    def _build_call_transform(
+        self,
+    ) -> Callable[[CallContext], str] | None:
+        """Build the ``:call-transform:`` callback from the template.
+
+        ``$index`` and ``$zipped`` are resolved before ``$call`` / ``$0``
+        so a placeholder-like substring inside the rendered call
+        expression is never re-expanded.
+        """
+        template: str | None = self.options.get("call-transform")
+        if template is None:
+            return None
+        resolved_template = template
+
+        def _call_transform(context: CallContext) -> str:
+            """Substitute call-context placeholders in the template."""
+            zipped = "" if context.zipped is None else context.zipped
+            result = resolved_template.replace(
+                "$index",
+                str(object=context.index),
+            )
+            result = result.replace("$zipped", zipped)
+            result = result.replace("$call", context.call)
+            return result.replace("$0", context.call)
+
+        return _call_transform
+
+    def _resolve_zip_source(
+        self,
+    ) -> tuple[str | None, InputFormat | None]:
+        """Read the optional ``:zip-file:`` and resolve its format."""
+        zip_file_value: str | None = self.options.get("zip-file")
+        if zip_file_value is None:
+            return None, None
+        env = self.state.document.settings.env
+        zip_path = (Path(env.srcdir) / zip_file_value).resolve()
+        env.note_dependency(str(object=zip_path))
+        zip_input_format = self._resolve_format(
+            data_path=zip_path,
+            option_name="zip-input-format",
+        )
+        return zip_path.read_text(encoding="utf-8"), zip_input_format
 
     def run(self) -> list[nodes.Node]:
         """Read the data file and produce function call expressions."""
@@ -682,18 +759,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         ]
         per_element: bool = "per-element" in self.options
 
-        call_transform_template: str | None = self.options.get(
-            "call-transform",
-        )
-        call_transform: Callable[[str], str] | None = None
-        if call_transform_template is not None:
-            template = call_transform_template
-
-            def _call_transform(call_str: str) -> str:
-                """Replace ``$0`` with the call expression."""
-                return template.replace("$0", call_str)
-
-            call_transform = _call_transform
+        call_transform = self._build_call_transform()
 
         ref_case, ref_key = self._resolve_ref_options()
         collection_layout = self._resolve_collection_layout()
@@ -714,6 +780,8 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             )
         )
 
+        zip_source, zip_input_format = self._resolve_zip_source()
+
         input_format = self._resolve_input_format(data_path=data_path)
         try:
             with _literalize_errors_as_extension_errors():
@@ -724,6 +792,8 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                     target_function=target_function,
                     parameter_names=parameter_names,
                     call_transform=call_transform,
+                    zip_source=zip_source,
+                    zip_input_format=zip_input_format,
                     per_element=per_element,
                     ref_case=ref_case,
                     consumable_refs=consumable_refs,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4578,6 +4578,134 @@ def test_literalizer_call_call_transform(
     assert content_html == expected_html
 
 
+def test_literalizer_call_call_transform_index(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The :call-transform: template exposes the zero-based call
+    position as ``$index``.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42, "hello"], [False, 99, "world"]]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: my_func
+           :parameter-names: flag,count,name
+           :per-element:
+           :call-transform: result_$index = $call
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           result_0 = my_func(flag=True, count=42, name="hello")
+           result_1 = my_func(flag=False, count=99, name="world")
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_literalizer_call_zip_file(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:zip-file: pairs a parallel data file with the generated calls,
+    surfacing each element as ``$zipped`` rendered as a native literal.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42, "hello"], [False, 99, "world"]]),
+    )
+    (source_directory / "expected.json").write_text(
+        data=json.dumps(obj=["first", "second"]),
+    )
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: my_func
+           :parameter-names: flag,count,name
+           :per-element:
+           :zip-file: expected.json
+           :call-transform: assert $call == $zipped
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           assert my_func(flag=True, count=42, name="hello") == "first"
+           assert my_func(flag=False, count=99, name="world") == "second"
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
 def test_literalizer_call_racket(
     *,
     make_app: Callable[..., SphinxTestApp],
@@ -6092,4 +6220,45 @@ def test_fortran_language_version_v2003(
         "    fint(2_int64)\n"
         "])"
     )
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_tuple_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Rust's :heterogeneous-strategy: tuple renders a fixed-length
+    heterogeneous scalar array as a native tuple instead of raising.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, True, "x"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: tuple
+           :include-delimiters:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == '(\n    1,\n    true,\n    "x",\n)'
     app.cleanup()

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.15"
+version = "2026.5.15.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -676,9 +676,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/dc/891552ed9caffba1a03e3f2cebe551e8e34af1b49f808600af53f0da4b37/literalizer-2026.5.15.tar.gz", hash = "sha256:c83ae8cca007c309bbfd83767cf2dddc003629f1b847771449c9e435be269d6f", size = 2450365, upload-time = "2026-05-15T14:39:08.907Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/8d/e865872f7b887a9b2829a697466fbd0abb493a93dd0d85e0647509e25105/literalizer-2026.5.15.2.tar.gz", hash = "sha256:bb46ad5f58eecc69e1ace1a492292bbffa62025f132313b52709e6fb5af06821", size = 2551380, upload-time = "2026-05-15T21:00:06.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/85/f29a4d5fdb14dc8db378c9f8243e5058140f1d67117a5ac1c19d8006e938/literalizer-2026.5.15-py3-none-any.whl", hash = "sha256:50884c6ec450edcbba2848807c9a8446f827512fb98455ec2750eb8049d6d429", size = 583091, upload-time = "2026-05-15T14:39:06.329Z" },
+    { url = "https://files.pythonhosted.org/packages/19/3a/2d0658898d631da96be9fb843c41602663ad966fec835d533e266f7e1e3b/literalizer-2026.5.15.2-py3-none-any.whl", hash = "sha256:f601d93befe6714aec0779621f0b1f3d0e3eb93bb5146136658c97f2b6f044af", size = 601085, upload-time = "2026-05-15T21:00:03.941Z" },
 ]
 
 [[package]]
@@ -1884,7 +1884,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.15" },
+    { name = "literalizer", specifier = "==2026.5.15.2" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.0" },
@@ -1907,11 +1907,11 @@ requires-dist = [
     { name = "sphinx-pyproject", marker = "extra == 'dev'", specifier = "==0.3.0" },
     { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },
-    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.35" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.36" },
     { name = "types-docutils", marker = "extra == 'dev'", specifier = "==0.22.3.20260508" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
-    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.24.1" },
+    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.25.0" },
 ]
 provides-extras = ["dev", "release"]
 
@@ -2130,27 +2130,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.35"
+version = "0.0.36"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/53/440e7b1212c4b0abbd4adb7aed93f4971aa1f8dca386ac5515930afa9172/ty-0.0.35.tar.gz", hash = "sha256:8375c240ab38138a19db07996c9808fb7a92047c1492e1ce587c2ef5112ad3a9", size = 5629237, upload-time = "2026-05-10T18:25:17.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/bf/4baa1533937246861afcf27a84a3bbf1a536729fc40fdbbf6c99c4218dac/ty-0.0.36.tar.gz", hash = "sha256:0350a4edc956f165ab1d1c92db3b74526fcaae16921095b63c3c6a8be313b2ff", size = 5643311, upload-time = "2026-05-15T10:19:37.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/84/19662ee881675815b7fafff940a365be1985730465afd9b75cb2edd5f8b3/ty-0.0.35-py3-none-linux_armv6l.whl", hash = "sha256:85ae1e59b9fb0b40e9d84fe61b29653c5f2f5e78b487ece371a7a38c20c781cf", size = 11198741, upload-time = "2026-05-10T18:24:49.378Z" },
-    { url = "https://files.pythonhosted.org/packages/62/df/7e5b6f83d85b4d2e5b72b5dceb388f440acc10679417bd46f829b9200fab/ty-0.0.35-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:709dbb7af4fcadb1196863c00b8791bbbbcc9dacbe15a0ff17f0af82b35d415b", size = 10948304, upload-time = "2026-05-10T18:24:58.246Z" },
-    { url = "https://files.pythonhosted.org/packages/59/94/72d7263aca055cde427f0ebcf08d6a74e5a5fee1d1e7fdd553696089cecb/ty-0.0.35-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2cb0877419ab0c8708b6925cb0c2800b263842bd3c425113f200538772f3a0cc", size = 10407413, upload-time = "2026-05-10T18:24:37.422Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/23/fda6fae8a81ce0cb5f24cdfe63260e110c7af8844e31fa07d1e6e8ef0232/ty-0.0.35-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7afbcfc61904b7e82e7fe1a1db832a40d8f01e69dee1775f6594e552980536c", size = 10932614, upload-time = "2026-05-10T18:24:47.401Z" },
-    { url = "https://files.pythonhosted.org/packages/72/3d/b98d8d4aa1a5ed6daaf15864e838f605ca7b1e8b93b7e17b96ed4bc4dfed/ty-0.0.35-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b61498cc3e4178031c079951257fbdb209a891b4feb10ad6c40f615a51846f41", size = 10962982, upload-time = "2026-05-10T18:24:44.88Z" },
-    { url = "https://files.pythonhosted.org/packages/18/c4/2881aad71bf6fb2f8df17fc8e4bc89e904e54490a3ee747b5ef73f98ac85/ty-0.0.35-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:573b1eacda349fc8dba0d767b41631c3a6f66412363127c5bf2b1b40a1d898d2", size = 11476274, upload-time = "2026-05-10T18:24:42.4Z" },
-    { url = "https://files.pythonhosted.org/packages/34/0f/7717650adaeaddd23eea70470e2c26d3f0b9b18fdc7f26ec9552d6001f17/ty-0.0.35-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7209746158d6393c1040aa64b3ca29622e212ea7d8bae22ba50dbcbb4f96f0a", size = 12012027, upload-time = "2026-05-10T18:25:00.752Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c9/1a16cb4aab6f4707d8f550772e91abc26d1c8870f19b5e2453ad10bb8209/ty-0.0.35-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4466a1470aa4418d49a9aa45d9da7de42033addd0a2837c5b2b0eb71d3c2bcd3", size = 11648894, upload-time = "2026-05-10T18:25:12.44Z" },
-    { url = "https://files.pythonhosted.org/packages/18/a1/a977c0e07e9f88db9c67f90c6342a4dc4422c8091fa07bf26521870687c5/ty-0.0.35-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb44bb742d52c309dcaa6598bcf4d82eb4bf1241b9e4940461e522e30093fe8b", size = 11560482, upload-time = "2026-05-10T18:25:05.172Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c1/a5fb11227d5cc4ac3f29a115d8c8bc817578e8ef6907d1e4c914ddbf45ee/ty-0.0.35-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:34b219250736c989b2670a03782c61315f523f3a2be37f1f90b1207e2212c188", size = 11718495, upload-time = "2026-05-10T18:24:54.12Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/cb/e92e4317388b6d1fd821a46941b448a8a1ff0bf13e22147c5167d8fa1b00/ty-0.0.35-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:88e2ac497decc0940ef1a07571dee8a746112a93a09cdc7f8bca0099752e2e05", size = 10900815, upload-time = "2026-05-10T18:25:02.941Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/4f/03bd87388a92567f262f35ac64e10d2be047d258f2dfcf1405f500fa2b90/ty-0.0.35-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:02cae51b53e6ec17d5d827ff1a3a76fd119705b56a92156e04399eda6e911596", size = 10998051, upload-time = "2026-05-10T18:25:14.68Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/60/6edbc375ee6073973200096168f644e1081e5e55a7d42596826465b275de/ty-0.0.35-py3-none-musllinux_1_2_i686.whl", hash = "sha256:11871d730c9400d899ac0b9f3d660ed2e7e433377c8725549f8250a36a7f2620", size = 11148910, upload-time = "2026-05-10T18:24:51.842Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/b1/a845d2066ed521c477450f436d4bd353d107e7c02dd6536a485944aaf892/ty-0.0.35-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1ad0a2f0530d0933dcc99ad36ac556c63e384ea72ab9a18d23ad2e2c9fd61c73", size = 11671005, upload-time = "2026-05-10T18:24:56.223Z" },
-    { url = "https://files.pythonhosted.org/packages/73/81/1d5912a54fb66b2f95ac828ae61d422ef5afeae1263e4d231e40796c229f/ty-0.0.35-py3-none-win32.whl", hash = "sha256:0e25d63ec4ab116e7f6757e44d16ca9216bca679d19ecc36d119cf80faada61a", size = 10481096, upload-time = "2026-05-10T18:24:39.976Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/36/1c7f8632bfec1c321f01581d4c940a3617b24bd3e8b37c8a7363d33fbfc4/ty-0.0.35-py3-none-win_amd64.whl", hash = "sha256:6a0a6d259f6f2f8f2f954c6f013d4e0b5eba68af6b353bf19a47d59ec254a3d5", size = 11555691, upload-time = "2026-05-10T18:25:07.792Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/fb/59325221bce52f6e833d6865ce8360ef7d5e1e21151b38df6dc77c4327a7/ty-0.0.35-py3-none-win_arm64.whl", hash = "sha256:619c52c0fb2aa21961a848a1995135ad3b6d0a9aa54da0194e60f679cc200e13", size = 10925457, upload-time = "2026-05-10T18:25:10.352Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/08/83e6f1a8aad5fef237373c020628e3703b2a79cae134df7ae74a074b23ca/ty-0.0.36-py3-none-linux_armv6l.whl", hash = "sha256:c70fae86e68717969101ee4da11e2077efd55ea3ac4e1478b9dccf600d561086", size = 11236491, upload-time = "2026-05-15T10:19:51.863Z" },
+    { url = "https://files.pythonhosted.org/packages/05/08/39fc4f4acf4430a1a2bd5f1698ac28a6d39e4c93b0e363b6ee19b5e0f5f4/ty-0.0.36-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:543410bc78f38d351a388c29c6e7e0a646decdf0e8fb6b47496056030efab76f", size = 10984361, upload-time = "2026-05-15T10:19:20.755Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f3/92d2bc59922c0ae6baa7476a815dbfe216f7a7f8ff3a801012a330acdbe3/ty-0.0.36-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a9f568ca71245f198278be8a73c30b87194277e3c8f328bb053e68399dd8dc91", size = 10423126, upload-time = "2026-05-15T10:19:45.722Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b2/f03701dbb5513b833680d7fd845e7e521bf8ae290eae465175049263b989/ty-0.0.36-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f951b2845f39a12624f3beececc3063a12ce1212c11916d3557e7e78998c9d2", size = 10943043, upload-time = "2026-05-15T10:19:23.708Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/32/5a186144fa4fbdace1f263047d58e2c89ac828cee4b5dda2b7dbb3496ad3/ty-0.0.36-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:45952006bf810deb25e1c4dfe9977a3cb8e9e675b2b491a6fd46717210a4a970", size = 11020866, upload-time = "2026-05-15T10:19:39.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/0f/a8f6e63eaf0c3445b076f2bf07f97440ac548db06bb892097b22351e26df/ty-0.0.36-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e0d7d7c14f789e66fb0296c6c1facf07e519ff5d6d0250ffc3d54479f50cf88", size = 11507375, upload-time = "2026-05-15T10:19:54.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e2/0556e4253c285d2166037e009f50f82799f93c56ceb1c574a40da851333c/ty-0.0.36-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4873e1ae8d99c67296d7908c1be70da0f6a644746751c619b49cebeff0816509", size = 12043426, upload-time = "2026-05-15T10:19:26.254Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0b/915d9c41ac95ab753b78b96779b94a7fe846d5715182b96d4b06c14e5910/ty-0.0.36-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e376cb976e9a8a4a5900f6e322ea4c8ac1dad0a6a8c9a10d5b15e87b8cf3f88", size = 11676680, upload-time = "2026-05-15T10:19:57.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/c356541929121004aeecc2e72d4e53185d59413d78a37f27eff83292369e/ty-0.0.36-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a002bbcc8ea6dd34b79463ae147f36e5c46ed9676767c0bc307a48e92e5e5dac", size = 11594362, upload-time = "2026-05-15T10:19:18.184Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/6b/aba45733431791fb7dadbb44550bbb3bdc909f7c551538d8a804639c5f4c/ty-0.0.36-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a489fe80d42cd23c06ac8304bcbf07712f976655ca1a0e6b05040b53ccdc252b", size = 11749166, upload-time = "2026-05-15T10:19:34.969Z" },
+    { url = "https://files.pythonhosted.org/packages/28/32/9a5bd2d6512ee0b4496df36521162c142f0fec8f6c33889a0bbbfe8b91f7/ty-0.0.36-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4a19d1ca362c8c2ea85dccb39d314aaa560cec77f618fcfc6d2e056253ca552b", size = 10923862, upload-time = "2026-05-15T10:19:31.9Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f1/cbaf5a560c13d25842685d32afecedc193f8c9e6f7f8f03974616eb3361f/ty-0.0.36-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0ea83a24b4a5cf1c0421c436569e70648073a20eb9d31af3ae434dde28070cb2", size = 11057070, upload-time = "2026-05-15T10:20:00.293Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5e/6c40145836825144600d3378cd6d6d2287ad3c079c86ceeedc4c35093394/ty-0.0.36-py3-none-musllinux_1_2_i686.whl", hash = "sha256:642421a4c56ea1a403e706dc22d0206bd5a76b08fca702ed7c7f43664b586569", size = 11184165, upload-time = "2026-05-15T10:19:29.036Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5f/e9ea4193c9b01da05691064f38bcb107460c92055266dd43f8d457e82305/ty-0.0.36-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:248f933e58d3295a54438c08e8289ae782aa12c96c2d10adcaef77f973ab536d", size = 11688416, upload-time = "2026-05-15T10:19:12.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/13/576a6ec0226388d457e2ffd677485d8f532d8c852f2d8b6278c4d82813d7/ty-0.0.36-py3-none-win32.whl", hash = "sha256:0c5c806444904bb66506ea6811a751caa93860838d01210fad7f9100370c4ce9", size = 10503333, upload-time = "2026-05-15T10:19:48.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ba/e0b42be5920f56f49b1d6b5f77fd0668e4a5c94f63402bcdc3ee53511a11/ty-0.0.36-py3-none-win_amd64.whl", hash = "sha256:79d4adf8e4ffe12b3adc822874bce963993f0de904ddb5daa9599f38e53d602a", size = 11574185, upload-time = "2026-05-15T10:19:15.177Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/77/42de5de13d5e473c5fb4667cb2cc1efa5d3c07df4a43d11ca4a6d6c62223/ty-0.0.36-py3-none-win_arm64.whl", hash = "sha256:a392731f68a5eff66346fdcb831d370d5e3c49aabae805081b4b70c0b6a3093b", size = 10939643, upload-time = "2026-05-15T10:19:42.593Z" },
 ]
 
 [[package]]
@@ -2251,18 +2251,18 @@ wheels = [
 
 [[package]]
 name = "zizmor"
-version = "1.24.1"
+version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/98/21be481ab5c08d976e59409828cfcb460a32a737415cf4e9c3f3280acc0b/zizmor-1.24.1.tar.gz", hash = "sha256:54ebb7a7061ebaa3a373126dcbafe970c9228fe274cfc40776a9714d2095b5e6", size = 501427, upload-time = "2026-04-13T18:01:34.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/e3/827a6d882397a9eb006b65755839bfa0a44286017afe11d4fb92d949bfb9/zizmor-1.25.0.tar.gz", hash = "sha256:a49bf420679fd35143814a35ac0e21826afee3ac322728409fac3955ae2d8f60", size = 517585, upload-time = "2026-05-14T20:50:49.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/0d/c932a14dfe7d3fed5dbf26a7bf1b7b9dbf277cef1d0b76fbcddae386442d/zizmor-1.24.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fd7c4953aa438aae599db69ed70ac687995e9e3314208bf1be5336479d556c8e", size = 9123014, upload-time = "2026-04-13T18:01:28.834Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/cc/f87ff2ccb9c57f4a1e5e9bd0351f9c84dc724fbd61b8ef70bc7e8abc1e0e/zizmor-1.24.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f44379019188b1a18d560614ab8abac7ce10553ad2ab57d519fa1c214881ff95", size = 8664275, upload-time = "2026-04-13T18:01:24.588Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/64/1dfa166dea03ddff23ee3d6c6ebce8322766f7188e008aa0d3612af3e709/zizmor-1.24.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:9b0689c55854edb0f3e6430321a93ca0081d8e34028cdcb47b9504f8a8559c27", size = 8837100, upload-time = "2026-04-13T18:01:18.708Z" },
-    { url = "https://files.pythonhosted.org/packages/65/67/cc411d605fec63b70558d572eb3fc2dbe4e596753e747b74daf5b795c1ed/zizmor-1.24.1-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:61f39674d5ea29640c4b09f3c239b3c9824c646bc790fa3680022e7bb569b375", size = 8430633, upload-time = "2026-04-13T18:01:20.757Z" },
-    { url = "https://files.pythonhosted.org/packages/76/86/f8dfffc7a5348c41bc17dea1f1796ac1a56d5e448f26a4193bc65996f571/zizmor-1.24.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:73083efc7a65e5a58f4439dd781cdcb0394b05a3750e664c7f7e414589dc49b1", size = 9263074, upload-time = "2026-04-13T18:01:31.403Z" },
-    { url = "https://files.pythonhosted.org/packages/14/62/db19dd027b412e92bbea8bd311b733d7726402ee3c734033c714125348f1/zizmor-1.24.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d36a2ba3b6d839acd4542f1a8f42bc34ff902cbff302cdf7916cb4e49dc8c5cc", size = 8863996, upload-time = "2026-04-13T18:01:35.929Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/28/c4f220a14cb100ecc965ea0faed1c1229139861a55e792522274221988b3/zizmor-1.24.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ff5acdd10c66ac27396c0fe14e4604933f6c622ffda38a6aa2857b99c75f5108", size = 8382934, upload-time = "2026-04-13T18:01:27.014Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/df/9593e8851424738a3b682be8958abf0e6a2c170e0c880d7b3bfb5d9eaf15/zizmor-1.24.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b2d873816137296ca5633ad240a574ce49374009a39d43f78a1675e2dba1ab52", size = 9352624, upload-time = "2026-04-13T18:01:16.672Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/b9/2c4fe526fc02926206903bfc72dbfbc215f01728eccef8135363d57890c9/zizmor-1.24.1-py3-none-win32.whl", hash = "sha256:c87812173fef2a3449d269e50e93b67b2f40826d10464c7add0c0fd7f0523a2c", size = 7496962, upload-time = "2026-04-13T18:01:22.773Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/24/710149e5d64d474103165b9eef6f7698827ef2fbb762b034ebc02b11a816/zizmor-1.24.1-py3-none-win_amd64.whl", hash = "sha256:9a0e552bf84f146699a0231dc42cf2cd5cfe140e3f08ff867ac154f62fc1ac2e", size = 8550658, upload-time = "2026-04-13T18:01:33.13Z" },
+    { url = "https://files.pythonhosted.org/packages/64/41/19e67e4b21c36b943e4123164f641ac1dddbda38f918758a8fd157d705a5/zizmor-1.25.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e388a0a02f323eac9de1b7af56d525665574d7b07952d828fc63b148a988d9db", size = 9132939, upload-time = "2026-05-14T20:50:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/c48d5d824ccf2007426987f5648a0ef187556c31868b2d47af12f056b2af/zizmor-1.25.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fc2b8765156e8e1bea2f9e0937a1e3b1f60a7998a120cbe870b83d0c8e4626de", size = 8683026, upload-time = "2026-05-14T20:50:44.32Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/25a9d19957663fd6278bd75ea086e8b51c6b5dfa378ea9e23274605b6a0d/zizmor-1.25.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:427d63982dd06e7daf3aaeb4780070d82b395825506e7dd35ba0c73e9b5a0558", size = 8845495, upload-time = "2026-05-14T20:51:02.88Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/bf/1cef30cccbd94687ecc01494220439c12ab79266f95387aa92adb625a12e/zizmor-1.25.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:6679e13a53a6ae183530980d47fe1f5550743d28d3a81f6ea694f1ce472d4545", size = 8466118, upload-time = "2026-05-14T20:50:54.986Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/18/d04d6abdb7e39a89bce6fb22a683a562b65b2c0a0649839cbed0affcd427/zizmor-1.25.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9f91e9f106e2688f17c607a822983b760b9781522edb5a38a89908c117042286", size = 9296873, upload-time = "2026-05-14T20:50:56.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/9c/6f8a01f8a2baa1cc591a6d5fe6b98efa747f108bb7d60e9e77e7d5af2956/zizmor-1.25.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6a56c67adfcb2384027e193cbb7d7f9511f22c8b6898bbd7adbef87f0e39c811", size = 8875094, upload-time = "2026-05-14T20:50:53.296Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5b/3be1deaf41263cb1e0a5b716aae7ed4e9873eca2bd45901ced62c9de83e6/zizmor-1.25.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:045d542be3005f797e0bcf50c56e6f313fdd5d56e3b105034153bf7eaec52535", size = 8419880, upload-time = "2026-05-14T20:50:46.287Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3a/ddb841376635a89c0655c47b025ee679f0ac8841a3ba6add119874c06f18/zizmor-1.25.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8bb513eba8b66cb292c5c8267e1974e662ca23ee39e26b4a3f10d653e7910769", size = 9380940, upload-time = "2026-05-14T20:50:48.35Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9c/c815bea8a6111c7b659b39d9b95d668969d2bda5eb6db61c2dcde0be363c/zizmor-1.25.0-py3-none-win32.whl", hash = "sha256:c0526defd163cb60c24c959fb4e84027b122f6801f4b0565f93af894ab72d453", size = 7549113, upload-time = "2026-05-14T20:51:01.047Z" },
+    { url = "https://files.pythonhosted.org/packages/72/97/9295f8a878049f30d4bc226fa8a063a5bc5d498535993178a4e8e76b4edd/zizmor-1.25.0-py3-none-win_amd64.whl", hash = "sha256:43a7b91c8359856bda7cffa9eb6aa4d362e0bf51136c6e494ca4d621ad8b411b", size = 8643760, upload-time = "2026-05-14T20:50:58.97Z" },
 ]


### PR DESCRIPTION
Bumps `literalizer` from 2026.5.15 to 2026.5.15.2 and adapts to the upstream API changes: removes the two deleted exception imports and adopts the new `CallContext` signature for `literalize_call`'s `call_transform` (both were breaking). Enriches the `:call-transform:` template with `$call`, `$index`, and `$zipped` placeholders (`$0` still works) and adds new `:zip-file:` / `:zip-input-format:` options on `literalizer-call` that wire upstream's `zip_source`/`zip_input_format`, registering the zip file as a build dependency. New user-facing literalizer errors are now surfaced as `ExtensionError` rather than tracebacks. The CHANGELOG and docs are updated, and tests cover the new `$index`, `:zip-file:` pairing, and Rust `tuple` heterogeneous-strategy behaviour. Full suite passes at 100% coverage and all pre-commit/pre-push lint stages are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the extension to match breaking upstream `literalizer` API changes and adds new directive options, which could affect generated snippets and build failures for existing docs.
> 
> **Overview**
> Upgrades `literalizer` to `2026.5.15.2` and updates the Sphinx extension to the new upstream APIs (notably `call_transform` now receives a `CallContext`, and new call/zip-related exceptions are re-raised as Sphinx `ExtensionError` instead of surfacing tracebacks).
> 
> Enhances `literalizer-call` with a richer `:call-transform:` template (`$call`/`$0`, `$index`) and introduces `:zip-file:`/`:zip-input-format:` to pair a parallel data file with generated calls and expose each matched element as `$zipped` (with the zip file tracked as a build dependency). Docs/changelog are updated and new tests cover `$index`, `:zip-file:` behavior, and Rust `:heterogeneous-strategy: tuple`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc3fe21c58e675b6629afdafce9081813507dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->