### PR TITLE
Bump literalizer to 2026.5.16 and adopt new APIs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.5.16``.
+- The ``literalizer-call`` directive gains a ``:comment-file:`` option:
+  a text file with one line per generated call whose non-blank lines
+  are emitted as trailing source comments after the matching call
+  (using the target language's comment syntax), with a blank line
+  emitting no comment.  This follows upstream ``literalizer`` adding
+  the ``comment_source`` argument to ``literalize_call``, which places
+  the comment after the statement terminator -- something a
+  ``:call-transform:`` cannot do without commenting out the
+  terminator.
+- ``CommentSourceLengthMismatchError`` (the ``:comment-file:`` line
+  count not matching the number of generated calls) and
+  ``CommentSourceMultilineError`` from ``literalizer`` are now surfaced
+  as a Sphinx ``ExtensionError`` rather than an uncaught traceback.
+- The ``:heterogeneous-strategy:`` option now accepts ``tuple`` for
+  ``cpp``, ``kotlin``, ``scala``, and ``typescript``, matching upstream
+  ``literalizer`` additions.
+
 2026.05.16
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -600,6 +600,15 @@ For positional-call languages like Go, the same data renders as:
    ``:zip-file:``.  Defaults to the format inferred from the
    ``:zip-file:`` extension.
 
+``:comment-file:`` (optional)
+   A text file with one line per generated call.  Each non-blank line
+   is emitted as a trailing source comment after the matching call,
+   using the target language's comment syntax, and a blank line emits
+   no comment for that call.  The number of lines must equal the
+   number of generated calls.  Unlike ``:call-transform:``, the
+   comment is placed after the statement terminator, so a comment can
+   be attached without commenting out the terminator.
+
 The ``literalizer-call`` directive also supports these shared options
 from the ``literalizer`` directive: ``:language:``, ``:input-format:``,
 ``:pre-indent-level:``, ``:indent:``, ``:indent-char:``,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.15.2",
+    "literalizer==2026.5.16",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -33,6 +33,8 @@ from literalizer.exceptions import (
     CallArgNotSupportedError,
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
+    CommentSourceLengthMismatchError,
+    CommentSourceMultilineError,
     DottedCallTargetNotSupportedError,
     ParameterCountMismatchError,
     PerElementNotListError,
@@ -251,6 +253,8 @@ _USER_FACING_LITERALIZER_ERRORS: tuple[type[Exception], ...] = (
     CallArgNotSupportedError,
     CallsNotSupportedByLanguageError,
     CallsNotSupportedByToolError,
+    CommentSourceLengthMismatchError,
+    CommentSourceMultilineError,
     DottedCallTargetNotSupportedError,
     PerElementNotListError,
     UnrepresentableInputError,
@@ -654,6 +658,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :call-transform: print($call)  # $call ($0), $index, $zipped
            :zip-file: expected.json
            :zip-input-format: json
+           :comment-file: comments.txt
            :input-format: json
            :indent: 4
            :indent-char: spaces
@@ -673,6 +678,12 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
     ``$index`` for the zero-based call position, and ``$zipped`` for the
     matching ``:zip-file:`` element rendered as a native literal (empty
     when no ``:zip-file:`` is given).
+
+    ``:comment-file:`` is a text file with one line per generated call;
+    each non-blank line is emitted as a trailing source comment after
+    that call (using the target language's comment syntax), and a blank
+    line emits no comment.  The line count must match the number of
+    generated calls.
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -686,6 +697,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             argument=x,
             values=("json", "json5", "yaml", "toml"),
         ),
+        "comment-file": directives.unchanged_required,
         "consumable-refs": directives.unchanged,
         "omit-code": directives.flag,
         "variable-name": directives.unchanged,
@@ -736,6 +748,22 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         )
         return zip_path.read_text(encoding="utf-8"), zip_input_format
 
+    def _resolve_comment_source(self) -> list[str] | None:
+        """Read the optional ``:comment-file:`` as one comment per call.
+
+        Each line becomes one ``comment_source`` entry, paired
+        positionally with a generated call; a blank line emits no
+        comment for that call.  A trailing newline does not add an
+        extra (empty) entry.
+        """
+        comment_file_value: str | None = self.options.get("comment-file")
+        if comment_file_value is None:
+            return None
+        env = self.state.document.settings.env
+        comment_path = (Path(env.srcdir) / comment_file_value).resolve()
+        env.note_dependency(str(object=comment_path))
+        return comment_path.read_text(encoding="utf-8").splitlines()
+
     def run(self) -> list[nodes.Node]:
         """Read the data file and produce function call expressions."""
         env = self.state.document.settings.env
@@ -781,6 +809,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         )
 
         zip_source, zip_input_format = self._resolve_zip_source()
+        comment_source = self._resolve_comment_source()
 
         input_format = self._resolve_input_format(data_path=data_path)
         try:
@@ -794,6 +823,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                     call_transform=call_transform,
                     zip_source=zip_source,
                     zip_input_format=zip_input_format,
+                    comment_source=comment_source,
                     per_element=per_element,
                     ref_case=ref_case,
                     consumable_refs=consumable_refs,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4706,6 +4706,115 @@ def test_literalizer_call_zip_file(
     assert content_html == expected_html
 
 
+def test_literalizer_call_comment_file(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:comment-file: emits one trailing comment per generated call,
+    using the target language's comment syntax, with a blank line
+    emitting no comment for that call.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42, "hello"], [False, 99, "world"]]),
+    )
+    (source_directory / "comments.txt").write_text(data="first case\n\n")
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: my_func
+           :parameter-names: flag,count,name
+           :per-element:
+           :comment-file: comments.txt
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           my_func(flag=True, count=42, name="hello")  # first case
+           my_func(flag=False, count=99, name="world")
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
+def test_literalizer_call_comment_file_length_mismatch(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A :comment-file: whose line count does not match the number of
+    generated calls is surfaced as a clean ExtensionError.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[True, 42, "hello"], [False, 99, "world"]]),
+    )
+    (source_directory / "comments.txt").write_text(data="only one\n")
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: my_func
+           :parameter-names: flag,count,name
+           :per-element:
+           :comment-file: comments.txt
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"comment_source has 1 entry\(ies\) but 2 call\(s\) were "
+            r"generated"
+        ),
+    ):
+        app.build()
+
+
 def test_literalizer_call_racket(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.15.2"
+version = "2026.5.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -676,9 +676,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8d/e865872f7b887a9b2829a697466fbd0abb493a93dd0d85e0647509e25105/literalizer-2026.5.15.2.tar.gz", hash = "sha256:bb46ad5f58eecc69e1ace1a492292bbffa62025f132313b52709e6fb5af06821", size = 2551380, upload-time = "2026-05-15T21:00:06.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/1f/ce29e69c706ef1446eadbf6db4a89c6971c3bf7ca7ffa837324634bfe33c/literalizer-2026.5.16.tar.gz", hash = "sha256:0ab2d8999635fffca36506189750195ccc60bf1b6a212770918e73035b0d80a8", size = 2619055, upload-time = "2026-05-16T12:11:12.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/3a/2d0658898d631da96be9fb843c41602663ad966fec835d533e266f7e1e3b/literalizer-2026.5.15.2-py3-none-any.whl", hash = "sha256:f601d93befe6714aec0779621f0b1f3d0e3eb93bb5146136658c97f2b6f044af", size = 601085, upload-time = "2026-05-15T21:00:03.941Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/15/f7646adc5f8bb6e76eed3ca9db7ea4634cfc3f14d9e463c78bd47f2a07f3/literalizer-2026.5.16-py3-none-any.whl", hash = "sha256:05dc83af29aa93ab85afcd72210aea66188d384ae1e9c37168e609ff51a6484b", size = 617737, upload-time = "2026-05-16T12:11:10.364Z" },
 ]
 
 [[package]]
@@ -1884,7 +1884,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.15.2" },
+    { name = "literalizer", specifier = "==2026.5.16" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.0" },


### PR DESCRIPTION
Bumps `literalizer` from `2026.5.15.2` to `2026.5.16` and adopts the new upstream APIs. Adds a `:comment-file:` option to `literalizer-call` wiring upstream's new `literalize_call` `comment_source` argument (one trailing source comment per generated call, blank line emits none), registered as a Sphinx build dependency. Surfaces the new `CommentSourceLengthMismatchError` and `CommentSourceMultilineError` as `ExtensionError` rather than tracebacks; `:heterogeneous-strategy:` now also accepts `tuple` for `cpp`, `kotlin`, `scala` and `typescript` via upstream additions (no code change needed). Updates the CHANGELOG and docs and adds tests for the new behaviour. Full suite (136 tests), ruff, ty, mypy, and a `-W` docs build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes directive option parsing and code generation output for `literalizer-call`, plus upgrades the upstream `literalizer` dependency; failures would surface as build-time errors or altered rendered snippets.
> 
> **Overview**
> Bumps the `literalizer` dependency to `2026.5.16` and updates lockfiles.
> 
> Adds a new `:comment-file:` option to the `literalizer-call` directive that reads a line-per-call text file, registers it as a Sphinx dependency, and passes it through to upstream `literalize_call(..., comment_source=...)` to emit trailing per-call comments (blank lines emit no comment).
> 
> Extends the set of caught upstream exceptions to surface `CommentSourceLengthMismatchError`/`CommentSourceMultilineError` as clean `ExtensionError`s, updates docs/changelog, and adds tests covering successful comment emission and length-mismatch error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8318c1336e96ed1543c4b9d36ed2db2fa2f6c1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->