### PR TITLE
Add heterogeneous-strategies docs page (#2238)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,10 +20,8 @@ Next
   as a Sphinx ``ExtensionError`` rather than an uncaught traceback.
 - The ``:heterogeneous-strategy:`` option now accepts ``tuple`` for
   ``cpp``, ``kotlin``, ``scala``, and ``typescript``, matching upstream
-  ``literalizer`` additions.  See :doc:`heterogeneous-strategies` for
-  the full strategy set, worked examples, and the per-language support
-  matrix; future strategy changes are summarized here and detailed
-  there.
+  ``literalizer`` additions.
+  See :doc:`heterogeneous-strategies` for the full strategy set, worked examples, and the per-language support matrix; future strategy changes are summarized here and detailed there.
 
 2026.05.16
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,10 @@ Next
   as a Sphinx ``ExtensionError`` rather than an uncaught traceback.
 - The ``:heterogeneous-strategy:`` option now accepts ``tuple`` for
   ``cpp``, ``kotlin``, ``scala``, and ``typescript``, matching upstream
-  ``literalizer`` additions.
+  ``literalizer`` additions.  See :doc:`heterogeneous-strategies` for
+  the full strategy set, worked examples, and the per-language support
+  matrix; future strategy changes are summarized here and detailed
+  there.
 
 2026.05.16
 ----------

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -1,0 +1,300 @@
+.. _heterogeneous-strategies:
+
+Heterogeneous strategies
+========================
+
+A *heterogeneous* collection is a list or mapping whose scalar values do
+not all share a single language-level type -- for example a JSON array
+``[1, "hello"]``, which mixes an integer and a string.  Dynamically
+typed source data routinely contains such collections, but many target
+languages have no single literal that can hold them.
+
+The ``:heterogeneous-strategy:`` option (on both the ``literalizer`` and
+``literalizer-call`` directives -- see :doc:`index`) selects how
+|project| renders these collections.  This page explains what each
+strategy emits, when each is appropriate, and which languages expose
+which strategies.
+
+The default: ``error``
+----------------------
+
+Every language defaults to ``error``: a collection that mixes scalar
+types raises rather than emitting a literal that would not compile.
+This is deliberate -- silently coercing ``1`` and ``"hello"`` to a
+common type would change the data.  The remaining strategies are
+opt-in, language-specific ways to represent the mixed collection
+faithfully instead of failing.
+
+The directive:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: rust
+
+with ``data.json`` containing ``[1, "hello"]`` raises an
+``ExtensionError`` describing the heterogeneous scalar types.
+
+Choosing a strategy
+-------------------
+
+``error``
+   Keep strict typing.  Appropriate when mixed-scalar collections in the
+   source data are a mistake you want surfaced rather than rendered.
+
+``tagged_enum`` / ``object_variant`` / ``union_type`` / ``interface`` / ``variant``
+   Wrap each value in a generated sum type so a *list* (or list-shaped
+   mapping) of mixed scalars round-trips.  Appropriate when the
+   collection is genuinely a sequence of "one of several scalar types".
+   These differ only in the host language's idiom for a tagged union;
+   the modeling is the same.
+
+``record``
+   Render a *mapping* whose values mix scalars and containers as a
+   generated ``struct`` declaration plus a matching struct literal.
+   Appropriate when the mapping is record-shaped (non-empty, string
+   keys) -- each key becomes a typed field, so values may legitimately
+   differ per field.
+
+``tuple``
+   Render a fixed-length list of mixed scalars as the language's native
+   tuple.  Appropriate when position, not iteration, carries meaning and
+   no extra preamble declaration is wanted.
+
+Strategies are not mutually exclusive across data shapes: the same
+language may pick ``record`` for a mapping and one of the sum-type
+strategies for a list.  Each language exposes only the subset listed in
+`Per-language support`_ below.
+
+Worked examples
+---------------
+
+Each example uses ``:include-preamble:`` so the generated declaration is
+shown alongside the literal.  Without that flag only the literal (the
+second block) is emitted.
+
+``tagged_enum`` (Rust)
+~~~~~~~~~~~~~~~~~~~~~~
+
+With ``data.json`` containing ``[1, "hello"]``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: rust
+      :heterogeneous-strategy: tagged_enum
+      :include-preamble:
+
+renders:
+
+.. code-block:: rust
+
+   enum Value {
+       I32(i32),
+       Str(&'static str),
+   }
+
+   vec![
+       Value::I32(1),
+       Value::Str("hello"),
+   ]
+
+``record`` (Go)
+~~~~~~~~~~~~~~~
+
+With ``data.json`` containing ``{"name": "a", "count": 1, "items": [1, 2]}``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: go
+      :heterogeneous-strategy: record
+      :include-preamble:
+
+renders:
+
+.. code-block:: go
+
+   package main
+   type Record0 struct {
+       Name string
+       Count int
+       Items []int
+   }
+
+   Record0{
+       Name: "a",
+       Count: 1,
+       Items: []int{
+           1,
+           2,
+       },
+   }
+
+``tuple`` (Rust)
+~~~~~~~~~~~~~~~~
+
+With ``data.json`` containing ``[1, "hello", true]``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: rust
+      :heterogeneous-strategy: tuple
+
+renders (no preamble -- the tuple is a native literal):
+
+.. code-block:: rust
+
+   (
+       1,
+       "hello",
+       true,
+   )
+
+``object_variant`` (Nim)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+With ``data.json`` containing ``[1, "hello"]``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: nim
+      :heterogeneous-strategy: object_variant
+      :include-preamble:
+
+renders:
+
+.. code-block:: nim
+
+   type
+     ValueKind = enum
+       vkInt, vkStr
+     Value = object
+       case kind: ValueKind
+       of vkInt: intVal: int
+       of vkStr: strVal: string
+
+   @[
+       Value(kind: vkInt, intVal: 1),
+       Value(kind: vkStr, strVal: "hello")
+   ]
+
+``union_type`` (Dhall)
+~~~~~~~~~~~~~~~~~~~~~~
+
+With ``data.json`` containing ``[1, "hello"]``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: dhall
+      :heterogeneous-strategy: union_type
+      :include-preamble:
+
+renders:
+
+.. code-block:: text
+
+   let Value = < Int : Integer | Str : Text > in
+
+   [
+     Value.Int +1,
+     Value.Str "hello",
+   ]
+
+``interface`` (V)
+~~~~~~~~~~~~~~~~~
+
+With ``data.json`` containing ``[1, "hello"]``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: v
+      :heterogeneous-strategy: interface
+      :include-preamble:
+
+renders:
+
+.. code-block:: text
+
+   interface IVal {}
+
+   [
+       IVal(1),
+       IVal('hello'),
+   ]
+
+``variant`` (Mojo)
+~~~~~~~~~~~~~~~~~~
+
+With ``data.json`` containing ``[1, "hello"]``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: mojo
+      :heterogeneous-strategy: variant
+      :include-preamble:
+
+renders:
+
+.. code-block:: text
+
+   from std.utils.variant import Variant
+   comptime Value = Variant[Int, String]
+
+   [
+       Value(1),
+       Value(String("hello")),
+   ]
+
+Per-language support
+--------------------
+
+``error`` is available for every language and is always the default.
+The table below lists the additional strategies each language exposes.
+Languages not listed support only ``error``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Strategy
+     - Languages
+     - Emits
+   * - ``tagged_enum``
+     - Rust
+     - A generated tagged ``enum`` plus wrapped values.
+   * - ``record``
+     - Go, Java, Kotlin, Rust, Scala
+     - A generated ``struct`` / record declaration plus a matching
+       literal, for record-shaped mappings.
+   * - ``tuple``
+     - C++, Rust
+     - The language's native fixed-length tuple.
+   * - ``object_variant``
+     - Nim
+     - A generated Nim object variant plus tagged values.
+   * - ``union_type``
+     - Dhall
+     - A generated Dhall union type plus tagged values.
+   * - ``interface``
+     - V
+     - A generated V ``interface`` plus wrapped values.
+   * - ``variant``
+     - Mojo
+     - A ``Variant`` alias plus wrapped values.
+
+Selecting a strategy a language does not support raises an
+``ExtensionError`` rather than silently falling back, so a typo such as
+``:heterogeneous-strategy: tagged_enum`` on a Go directive fails
+loudly.
+
+This matrix tracks the upstream `literalizer`_ release pinned by
+|project|; new languages and strategies are announced in the
+:doc:`changelog`.
+
+.. _literalizer: https://github.com/adamtheturtle/literalizer

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -3,27 +3,18 @@
 Heterogeneous strategies
 ========================
 
-A *heterogeneous* collection is a list or mapping whose scalar values do
-not all share a single language-level type -- for example a JSON array
-``[1, "hello"]``, which mixes an integer and a string.  Dynamically
-typed source data routinely contains such collections, but many target
-languages have no single literal that can hold them.
+A *heterogeneous* collection is a list or mapping whose scalar values do not all share a single language-level type -- for example a JSON array ``[1, "hello"]``, which mixes an integer and a string.
+Dynamically typed source data routinely contains such collections, but many target languages have no single literal that can hold them.
 
-The ``:heterogeneous-strategy:`` option (on both the ``literalizer`` and
-``literalizer-call`` directives -- see :doc:`index`) selects how
-|project| renders these collections.  This page explains what each
-strategy emits, when each is appropriate, and which languages expose
-which strategies.
+The ``:heterogeneous-strategy:`` option (on both the ``literalizer`` and ``literalizer-call`` directives -- see :doc:`index`) selects how |project| renders these collections.
+This page explains what each strategy emits, when each is appropriate, and which languages expose which strategies.
 
 The default: ``error``
 ----------------------
 
-Every language defaults to ``error``: a collection that mixes scalar
-types raises rather than emitting a literal that would not compile.
-This is deliberate -- silently coercing ``1`` and ``"hello"`` to a
-common type would change the data.  The remaining strategies are
-opt-in, language-specific ways to represent the mixed collection
-faithfully instead of failing.
+Every language defaults to ``error``: a collection that mixes scalar types raises rather than emitting a literal that would not compile.
+This is deliberate -- silently coercing ``1`` and ``"hello"`` to a common type would change the data.
+The remaining strategies are opt-in, language-specific ways to represent the mixed collection faithfully instead of failing.
 
 The directive:
 
@@ -32,46 +23,36 @@ The directive:
    .. literalizer:: data.json
       :language: rust
 
-with ``data.json`` containing ``[1, "hello"]`` raises an
-``ExtensionError`` describing the heterogeneous scalar types.
+with ``data.json`` containing ``[1, "hello"]`` raises an ``ExtensionError`` describing the heterogeneous scalar types.
 
 Choosing a strategy
 -------------------
 
 ``error``
-   Keep strict typing.  Appropriate when mixed-scalar collections in the
-   source data are a mistake you want surfaced rather than rendered.
+   Keep strict typing.
+   Appropriate when mixed-scalar collections in the source data are a mistake you want surfaced rather than rendered.
 
 ``tagged_enum`` / ``object_variant`` / ``union_type`` / ``interface`` / ``variant``
-   Wrap each value in a generated sum type so a *list* (or list-shaped
-   mapping) of mixed scalars round-trips.  Appropriate when the
-   collection is genuinely a sequence of "one of several scalar types".
-   These differ only in the host language's idiom for a tagged union;
-   the modeling is the same.
+   Wrap each value in a generated sum type so a *list* (or list-shaped mapping) of mixed scalars round-trips.
+   Appropriate when the collection is genuinely a sequence of "one of several scalar types".
+   These differ only in the host language's idiom for a tagged union; the modeling is the same.
 
 ``record``
-   Render a *mapping* whose values mix scalars and containers as a
-   generated ``struct`` declaration plus a matching struct literal.
-   Appropriate when the mapping is record-shaped (non-empty, string
-   keys) -- each key becomes a typed field, so values may legitimately
-   differ per field.
+   Render a *mapping* whose values mix scalars and containers as a generated ``struct`` declaration plus a matching struct literal.
+   Appropriate when the mapping is record-shaped (non-empty, string keys) -- each key becomes a typed field, so values may legitimately differ per field.
 
 ``tuple``
-   Render a fixed-length list of mixed scalars as the language's native
-   tuple.  Appropriate when position, not iteration, carries meaning and
-   no extra preamble declaration is wanted.
+   Render a fixed-length list of mixed scalars as the language's native tuple.
+   Appropriate when position, not iteration, carries meaning and no extra preamble declaration is wanted.
 
-Strategies are not mutually exclusive across data shapes: the same
-language may pick ``record`` for a mapping and one of the sum-type
-strategies for a list.  Each language exposes only the subset listed in
-`Per-language support`_ below.
+Strategies are not mutually exclusive across data shapes: the same language may pick ``record`` for a mapping and one of the sum-type strategies for a list.
+Each language exposes only the subset listed in `Per-language support`_ below.
 
 Worked examples
 ---------------
 
-Each example uses ``:include-preamble:`` so the generated declaration is
-shown alongside the literal.  Without that flag only the literal (the
-second block) is emitted.
+Each example uses ``:include-preamble:`` so the generated declaration is shown alongside the literal.
+Without that flag only the literal (the second block) is emitted.
 
 ``tagged_enum`` (Rust)
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -270,8 +251,7 @@ Languages not listed support only ``error``.
      - A generated tagged ``enum`` plus wrapped values.
    * - ``record``
      - Go, Java, Kotlin, Rust, Scala
-     - A generated ``struct`` / record declaration plus a matching
-       literal, for record-shaped mappings.
+     - A generated ``struct`` / record declaration plus a matching literal, for record-shaped mappings.
    * - ``tuple``
      - C++, Rust
      - The language's native fixed-length tuple.
@@ -288,13 +268,8 @@ Languages not listed support only ``error``.
      - Mojo
      - A ``Variant`` alias plus wrapped values.
 
-Selecting a strategy a language does not support raises an
-``ExtensionError`` rather than silently falling back, so a typo such as
-``:heterogeneous-strategy: tagged_enum`` on a Go directive fails
-loudly.
+Selecting a strategy a language does not support raises an ``ExtensionError`` rather than silently falling back, so a typo such as ``:heterogeneous-strategy: tagged_enum`` on a Go directive fails loudly.
 
-This matrix tracks the upstream `literalizer`_ release pinned by
-|project|; new languages and strategies are announced in the
-:doc:`changelog`.
+This matrix tracks the upstream `literalizer`_ release pinned by |project|; new languages and strategies are announced in the :doc:`changelog`.
 
 .. _literalizer: https://github.com/adamtheturtle/literalizer

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -453,6 +453,11 @@ Directive options
       ``Record0{Name: "a", Items: []int{1}}``).  Available for Go and
       Rust.
 
+   See :doc:`heterogeneous-strategies` for the full set of strategies
+   (including ``tuple``, ``object_variant``, ``union_type``,
+   ``interface``, and ``variant``), worked examples, and the
+   per-language support matrix.
+
 ``:call-style:`` (optional)
    How ``literalizer-call`` renders function calls.  Each language
    offers its own set of call styles; using a value a language does not
@@ -624,6 +629,7 @@ Reference
 .. toctree::
    :maxdepth: 3
 
+   heterogeneous-strategies
    api-reference
    release-process
    changelog

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -453,10 +453,7 @@ Directive options
       ``Record0{Name: "a", Items: []int{1}}``).  Available for Go and
       Rust.
 
-   See :doc:`heterogeneous-strategies` for the full set of strategies
-   (including ``tuple``, ``object_variant``, ``union_type``,
-   ``interface``, and ``variant``), worked examples, and the
-   per-language support matrix.
+   See :doc:`heterogeneous-strategies` for the full set of strategies (including ``tuple``, ``object_variant``, ``union_type``, ``interface``, and ``variant``), worked examples, and the per-language support matrix.
 
 ``:call-style:`` (optional)
    How ``literalizer-call`` renders function calls.  Each language


### PR DESCRIPTION
Adds a dedicated `docs/source/heterogeneous-strategies.rst` guide covering what heterogeneous values mean in literalizer, all eight strategies (`error`, `tagged_enum`, `record`, `tuple`, `object_variant`, `union_type`, `interface`, `variant`) with guidance on when each applies and a worked example per strategy, plus a per-language support matrix. Every example and the matrix were generated from the pinned `literalizer` 2026.5.16 rather than hand-written. The page is wired into the toctree and cross-linked from the `:heterogeneous-strategy:` option in `index.rst` and from the CHANGELOG strategy-history entry so future strategy changes have a stable home. Verified with the CI-strict `sphinx-build -M html … -W` and all pre-commit hooks (doc8, sphinx-lint, etc.) passing.

Closes #2238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that add a new guide page and wire it into existing docs and the changelog, with no runtime behavior changes.
> 
> **Overview**
> Adds a new `heterogeneous-strategies` documentation page describing all `:heterogeneous-strategy:` modes, when to use them, worked examples, and a per-language support matrix.
> 
> Updates the `:heterogeneous-strategy:` option docs in `index.rst` and the `CHANGELOG.rst` entry to link to this new page, and includes it in the docs toctree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fedcaac25f17b6a7a69c5745f663d3dd478137b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->