### PR TITLE
Reject duplicate :record-shape-names: key sets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Next
 ----
 
+- Two ``:record-shape-names:`` entries for the same set of keys (in any
+  order) now raise a clean ``ExtensionError`` instead of silently
+  keeping only the last name.
+
 2026.05.16.1
 ------------
 

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -202,6 +202,13 @@ def _parse_record_shape_names(value: str) -> dict[frozenset[str], str]:
                 f"least one key and a non-empty name."
             )
             raise ExtensionError(message=msg)
+        if keys in result:
+            sorted_keys = ", ".join(sorted(keys))
+            msg = (
+                f"':record-shape-names:' has multiple entries for the "
+                f"key set {{{sorted_keys}}}."
+            )
+            raise ExtensionError(message=msg)
         result[keys] = name
     return result
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6578,6 +6578,49 @@ def test_record_shape_names_empty_name_error(
         app.build()
 
 
+def test_record_shape_names_duplicate_key_set_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Two :record-shape-names: entries for the same key set (in any
+    key order) raise a clear ExtensionError instead of silently
+    keeping only the last name.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"x": 1, "y": 2}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: java
+           :heterogeneous-strategy: record
+           :record-shape-names: x,y=Point; y,x=Other
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"':record-shape-names:' has multiple entries for the key "
+            r"set \{x, y\}\."
+        ),
+    ):
+        app.build()
+
+
 def test_record_shape_names_unsupported_language_error(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Addresses the Cursor Bugbot review on #206. `_parse_record_shape_names` stored entries in a `dict[frozenset[str], str]`, so two entries mapping the same key set in any order (e.g. `x,y=Point; y,x=Other`) silently collapsed to the last name, bypassing upstream's `InvalidRecordNameError` collision check and giving the user no warning. This now raises a clean `ExtensionError` when a key set appears more than once, with a new test covering the differently-ordered duplicate case and a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small validation change that only affects misconfigured directives, plus a new regression test and changelog note.
> 
> **Overview**
> Tightens validation of `:record-shape-names:` so **duplicate entries for the same key set (even in different key order)** now raise a clear `ExtensionError` instead of silently overriding the earlier name.
> 
> Adds a regression test for the differently-ordered duplicate case and documents the behavior change in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3817048c9649380ce8ba664dbd4ff94e015b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->