### PR TITLE
Add :heterogeneous-strategy: auto and :skip-if-unrepresentable: (#199)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,25 @@ Next
 - Two ``:record-shape-names:`` entries for the same set of keys (in any
   order) now raise a clean ``ExtensionError`` instead of silently
   keeping only the last name.
+- ``:heterogeneous-strategy:`` now accepts ``auto``.  It renders the
+  input with its natural representation first -- so homogeneous and
+  genuinely map-shaped data keep their native form -- and only if that
+  fails because the data is heterogeneous does it retry with each
+  strategy the target language supports, in the order given by the new
+  ``literalizer_heterogeneous_strategy_precedence`` configuration value
+  (default: ``record``, ``tuple``, ``tagged_enum``, ``object_variant``,
+  ``variant``, ``union_type``, ``interface``).  This removes the need to
+  pick a single per-project or per-input strategy.
+- Both directives gain a ``:skip-if-unrepresentable:`` flag.  When the
+  input cannot be represented in the target language (including after
+  ``auto`` exhausts its precedence), the directive emits no node instead
+  of failing the build, so a per-language loop can skip the languages a
+  given input does not fit without leaking data-shape concerns into
+  prose.
+- A ``HeterogeneousCollectionError`` raised by a concrete (non-``auto``)
+  ``:heterogeneous-strategy:`` that cannot represent the input is now
+  surfaced as a clean ``ExtensionError`` rather than an uncaught
+  traceback.
 
 2026.05.16.1
 ------------

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -28,6 +28,11 @@ with ``data.json`` containing ``[1, "hello"]`` raises an ``ExtensionError`` desc
 Choosing a strategy
 -------------------
 
+``auto``
+   Let |project| choose.
+   The input is rendered with its natural representation first, so homogeneous and genuinely map-shaped data keep their native form, and a strategy is only applied if that natural rendering fails because the data is heterogeneous.
+   See `Letting the directive choose: auto`_ below.
+
 ``error``
    Keep strict typing.
    Appropriate when mixed-scalar collections in the source data are a mistake you want surfaced rather than rendered.
@@ -47,6 +52,54 @@ Choosing a strategy
 
 Strategies are not mutually exclusive across data shapes: the same language may pick ``record`` for a mapping and one of the sum-type strategies for a list.
 Each language exposes only the subset listed in `Per-language support`_ below.
+
+Letting the directive choose: ``auto``
+--------------------------------------
+
+A realistic project rarely has one strategy that fits every input.
+A record-shaped dict needs ``record``; a genuinely map-shaped dict must stay a map; a list of mixed scalars needs a sum type or ``tuple``.
+``:heterogeneous-strategy: auto`` removes that per-input decision.
+
+``auto`` renders the input with its **natural representation first**.
+If that succeeds -- as it does for homogeneous data and for genuinely map-shaped mappings -- the native output is used unchanged, so ``auto`` never promotes a plain map to a generated record.
+Only if the natural rendering fails because the data is heterogeneous does ``auto`` retry, trying each strategy the target language supports in a configured precedence and using the first that represents the data.
+
+The precedence is the ``literalizer_heterogeneous_strategy_precedence`` configuration value (see :doc:`index`), restricted per directive to the strategies the target language exposes.
+It defaults to ``record``, ``tuple``, ``tagged_enum``, ``object_variant``, ``variant``, ``union_type``, ``interface``; ``error`` is never a fallback because it is the failure ``auto`` is recovering from.
+
+For example, with ``data.json`` containing ``[{"id": 1, "desc": "x", "blocks": [1, 2]}]``:
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: rust
+      :heterogeneous-strategy: auto
+
+the natural Rust map rendering fails (a ``HashMap`` cannot hold mixed value types), so ``auto`` falls back to ``record`` and renders:
+
+.. code-block:: rust
+
+   Record0 { id: 1, desc: "x", blocks: vec![1, 2] },
+
+The same directive with a homogeneous or map-shaped ``data.json`` emits the native ``HashMap`` instead, with no fallback applied.
+
+Skipping unrepresentable inputs
+-------------------------------
+
+Some inputs cannot be represented in some languages even with ``auto`` -- for instance a shape no strategy the language exposes can model.
+By default this fails the build, which is correct when every language must render every input.
+
+When a single canonical input is rendered across several languages (typically a Jinja loop over a language list), failing the whole build forces the data-shape knowledge -- "skip Rust for this one" -- into the template or prose.
+The ``:skip-if-unrepresentable:`` flag (on both directives) keeps that knowledge in the directive: when the input cannot be represented in the target language, including after ``auto`` exhausts its precedence, the directive emits no node instead of raising.
+
+.. code-block:: rst
+
+   .. literalizer:: data.json
+      :language: rust
+      :heterogeneous-strategy: auto
+      :skip-if-unrepresentable:
+
+Without ``:skip-if-unrepresentable:`` the same unrepresentable input raises an ``ExtensionError`` and fails the build, as before.
 
 Worked examples
 ---------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -458,6 +458,15 @@ Directive options
    How to render scalar collections whose elements have more than one
    language-level type.  Supported values:
 
+   ``auto``
+      Render the input with its natural representation first, and only
+      if that fails because the data is heterogeneous, retry with each
+      strategy the target language supports in the order given by the
+      ``literalizer_heterogeneous_strategy_precedence`` configuration
+      value.
+      Homogeneous and genuinely map-shaped data keep their native form,
+      so a single ``auto`` works across a mix of inputs without picking
+      a strategy per project or per file.
    ``error``
       Raise an error when a collection mixes scalar types (default for
       all languages).
@@ -479,6 +488,14 @@ Directive options
       Scala, and TypeScript.
 
    See :doc:`heterogeneous-strategies` for the full set of strategies (including ``tuple``, ``object_variant``, ``union_type``, ``interface``, and ``variant``), worked examples, and the per-language support matrix.
+
+``:skip-if-unrepresentable:`` (optional, flag)
+   Emit no node at all -- instead of failing the build -- when the
+   input cannot be represented in the target language, including after
+   ``:heterogeneous-strategy: auto`` exhausts its precedence.  This lets
+   a loop that renders the same data in several languages skip the
+   languages a given input does not fit, without moving data-shape
+   knowledge into the surrounding prose or template.
 
 ``:call-style:`` (optional)
    How ``literalizer-call`` renders function calls.  Each language
@@ -642,8 +659,29 @@ from the ``literalizer`` directive: ``:language:``, ``:input-format:``,
 ``:include-preamble:``, ``:language-version:``, ``:ref-case:``,
 ``:ref-key:``, ``:module-name:``, ``:record-struct-name-prefix:``,
 ``:record-shape-names:``, ``:wrap-in-file:``,
-``:collection-layout:``, and all format options (e.g.
+``:collection-layout:``, ``:heterogeneous-strategy:``,
+``:skip-if-unrepresentable:``, and all format options (e.g.
 ``:string-format:``, ``:trailing-comma:``, etc.).
+
+
+Configuration
+~~~~~~~~~~~~~
+
+``literalizer_heterogeneous_strategy_precedence``
+   The order in which ``:heterogeneous-strategy: auto`` tries
+   representational strategies after the natural representation fails.
+   It defaults to ``["record", "tuple", "tagged_enum",
+   "object_variant", "variant", "union_type", "interface"]`` and is
+   restricted, per directive, to the strategies the target language
+   exposes (``error`` is never a fallback).  Set it in :file:`conf.py`
+   to change which representation ``auto`` prefers, for example to
+   prefer a tagged union over a record::
+
+      literalizer_heterogeneous_strategy_precedence = [
+          "tagged_enum",
+          "record",
+          "tuple",
+      ]
 
 
 Reference

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -3,6 +3,7 @@ Changelog
 Dhall
 Fortran
 Initializer
+Jinja
 Jsonnet
 Lua
 MATLAB
@@ -32,5 +33,6 @@ datetimes
 dicts
 literalizer
 structs
+unrepresentable
 validator
 whitespace

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -24,6 +24,7 @@ from literalizer import (
     InputFormat,
     Language,
     LanguageCls,
+    LiteralizeResult,
     NewVariable,
     VariableForm,
     literalize,
@@ -36,6 +37,7 @@ from literalizer.exceptions import (
     CommentSourceLengthMismatchError,
     CommentSourceMultilineError,
     DottedCallTargetNotSupportedError,
+    HeterogeneousCollectionError,
     InvalidRecordNameError,
     ParameterCountMismatchError,
     PerElementNotListError,
@@ -228,6 +230,38 @@ def _make_format_validator(
     return validator
 
 
+# Sentinel value for ``:heterogeneous-strategy:`` that asks the directive
+# to pick a strategy itself instead of naming a literalizer enum member.
+_AUTO_STRATEGY = "auto"
+
+# Order in which ``:heterogeneous-strategy: auto`` tries representational
+# strategies *after* the natural representation fails.  Restricted per
+# directive to the strategies the target language actually exposes;
+# overridable via the ``literalizer_heterogeneous_strategy_precedence``
+# config value.  ``error`` is never a fallback -- it is the failure that
+# ``auto`` is recovering from.
+_DEFAULT_HETEROGENEOUS_STRATEGY_PRECEDENCE: tuple[str, ...] = (
+    "record",
+    "tuple",
+    "tagged_enum",
+    "object_variant",
+    "variant",
+    "union_type",
+    "interface",
+)
+
+
+def _heterogeneous_strategy_validator(x: str) -> str:
+    """Validate ``:heterogeneous-strategy:``, also accepting ``auto``."""
+    return directives.choice(
+        argument=x,
+        values=(
+            _AUTO_STRATEGY,
+            *_all_format_values()["heterogeneous-strategy"],
+        ),
+    )
+
+
 _COMMON_OPTIONS: dict[str, Callable[[str], Any]] = {
     "language": lambda x: directives.choice(
         argument=x,
@@ -248,6 +282,9 @@ _COMMON_OPTIONS: dict[str, Callable[[str], Any]] = {
         option_name: _make_format_validator(option_name=option_name)
         for option_name in _FORMAT_OPTION_GETTERS
     },
+    # ``auto`` is not a literalizer enum member, so this option needs a
+    # validator that accepts it alongside the per-language values.
+    "heterogeneous-strategy": _heterogeneous_strategy_validator,
     "default-set-element-type": directives.unchanged,
     "default-sequence-element-type": directives.unchanged,
     "default-dict-key-type": directives.unchanged,
@@ -256,6 +293,7 @@ _COMMON_OPTIONS: dict[str, Callable[[str], Any]] = {
     "module-name": directives.unchanged,
     "record-struct-name-prefix": directives.unchanged_required,
     "record-shape-names": directives.unchanged_required,
+    "skip-if-unrepresentable": directives.flag,
     "wrap-in-file": directives.flag,
     "ref-case": lambda x: directives.choice(
         argument=x,
@@ -293,7 +331,10 @@ _EXTENSION_TO_INPUT_FORMAT: dict[str, InputFormat] = {
 # Literalizer exceptions that signal a directive option combination the
 # selected language cannot represent.  Surfacing these as a clean
 # ``ExtensionError`` (rather than a traceback) lets the build report the
-# offending directive and continue under ``-W``.
+# offending directive and continue under ``-W``.  This includes
+# ``HeterogeneousCollectionError`` so a record-shaped or mixed-scalar
+# input rendered with a concrete (non-``auto``) strategy that cannot
+# represent it fails loudly rather than with a traceback.
 _USER_FACING_LITERALIZER_ERRORS: tuple[type[Exception], ...] = (
     CallArgNotSupportedError,
     CallsNotSupportedByLanguageError,
@@ -301,6 +342,7 @@ _USER_FACING_LITERALIZER_ERRORS: tuple[type[Exception], ...] = (
     CommentSourceLengthMismatchError,
     CommentSourceMultilineError,
     DottedCallTargetNotSupportedError,
+    HeterogeneousCollectionError,
     InvalidRecordNameError,
     PerElementNotListError,
     UnrepresentableInputError,
@@ -336,11 +378,23 @@ class _BaseLiteralizerDirective(SphinxDirective):
         self,
         language_name: str,
         constructor: partial[Language],
+        *,
+        heterogeneous_strategy_value: str | None,
     ) -> partial[Language]:
-        """Apply all format/enum options."""
+        """Apply all format/enum options.
+
+        ``heterogeneous-strategy`` is taken from
+        *heterogeneous_strategy_value* rather than the directive options
+        so the caller can vary it per attempt for ``auto``; the resolved
+        value is never the ``auto`` sentinel.
+        """
         all_formats = _all_formats()
         for option_name in _FORMAT_OPTION_GETTERS:
-            if (value := self.options.get(option_name)) is not None:
+            if option_name == "heterogeneous-strategy":
+                value = heterogeneous_strategy_value
+            else:
+                value = self.options.get(option_name)
+            if value is not None:
                 param_name = option_name.replace("-", "_")
                 constructor = partial(
                     constructor,
@@ -408,8 +462,16 @@ class _BaseLiteralizerDirective(SphinxDirective):
         self,
         language_name: str,
         language_cls: LanguageCls,
+        *,
+        heterogeneous_strategy_value: str | None,
     ) -> Language:
-        """Build a Language instance from directive options."""
+        """Build a Language instance from directive options.
+
+        *heterogeneous_strategy_value* is the concrete strategy name (or
+        ``None`` for the language default) to apply for this build; it is
+        kept separate from the directive options so ``auto`` can rebuild
+        the language with a different strategy per attempt.
+        """
         constructor = partial(language_cls)
 
         indent_count = self.options.get("indent")
@@ -425,6 +487,7 @@ class _BaseLiteralizerDirective(SphinxDirective):
         constructor = self._apply_format_options(
             language_name=language_name,
             constructor=constructor,
+            heterogeneous_strategy_value=heterogeneous_strategy_value,
         )
         constructor = self._apply_default_type_options(
             language_name=language_name,
@@ -599,6 +662,84 @@ class _BaseLiteralizerDirective(SphinxDirective):
         )
         return CollectionLayout[collection_layout_value.upper()]
 
+    def _auto_precedence(self, *, language_cls: LanguageCls) -> list[str]:
+        """Strategies ``auto`` falls back through, most preferred first.
+
+        The configured precedence
+        (``literalizer_heterogeneous_strategy_precedence``) restricted to
+        the strategies the target language exposes.  ``error`` is never
+        included -- it is the failure ``auto`` recovers from.
+        """
+        supported = {
+            member.name.lower()
+            for member in language_cls.HeterogeneousStrategies
+        }
+        precedence: list[str] = (
+            self.env.config.literalizer_heterogeneous_strategy_precedence
+        )
+        return [
+            name
+            for name in precedence
+            if name in supported and name != "error"
+        ]
+
+    def _render_with_strategy(
+        self,
+        *,
+        language_name: str,
+        language_cls: LanguageCls,
+        render: Callable[[Language], LiteralizeResult],
+    ) -> tuple[LiteralizeResult, Language] | None:
+        """Build the language and render, honoring ``auto`` and
+        ``:skip-if-unrepresentable:``.
+
+        For ``:heterogeneous-strategy: auto`` the natural representation
+        is tried first -- so homogeneous and genuinely map-shaped data
+        keep their native output -- then each strategy from
+        :meth:`_auto_precedence` in turn until one represents the data.
+
+        Returns ``(result, language)`` where *result* is what *render*
+        produced, or ``None`` when the input cannot be represented in the
+        target language and ``:skip-if-unrepresentable:`` is set (the
+        caller then emits no node).
+        """
+        hs_value: str | None = self.options.get("heterogeneous-strategy")
+        skip = "skip-if-unrepresentable" in self.options
+
+        if hs_value == _AUTO_STRATEGY:
+            attempts: list[str | None] = [
+                None,
+                *self._auto_precedence(language_cls=language_cls),
+            ]
+        else:
+            attempts = [hs_value]
+
+        for index, strategy_value in enumerate(iterable=attempts):
+            is_last = index == len(attempts) - 1
+            language_spec = self._build_language(
+                language_name=language_name,
+                language_cls=language_cls,
+                heterogeneous_strategy_value=strategy_value,
+            )
+            try:
+                return render(language_spec), language_spec
+            except HeterogeneousCollectionError as exc:
+                if hs_value == _AUTO_STRATEGY and not is_last:
+                    continue
+                if skip:
+                    return None
+                raise ExtensionError(message=str(object=exc)) from exc
+            except UnrepresentableInputError as exc:
+                if skip:
+                    return None
+                raise ExtensionError(message=str(object=exc)) from exc
+            except _USER_FACING_LITERALIZER_ERRORS as exc:
+                raise ExtensionError(message=str(object=exc)) from exc
+        # ``attempts`` is always non-empty, so the loop always returns or
+        # raises; this is unreachable and only satisfies the type checker.
+        msg = "no heterogeneous strategy produced a result"
+        raise ExtensionError(message=msg)
+
 
 @beartype
 class LiteralizerDirective(_BaseLiteralizerDirective):
@@ -636,7 +777,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :trailing-comma: yes
            :language-version: py39
            :empty-dict-key: positional
-           :heterogeneous-strategy: tagged_enum
+           :heterogeneous-strategy: auto
            :default-set-element-type: String
            :default-sequence-element-type: String
            :default-dict-key-type: String
@@ -646,10 +787,27 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :module-name: MyModule
            :record-struct-name-prefix: Record
            :record-shape-names: x,y=Point; a,b,c=Vec3
+           :skip-if-unrepresentable:
            :wrap-in-file:
            :ref-case: camel
            :ref-key: $reference
            :collection-layout: multiline
+
+    ``:heterogeneous-strategy: auto`` renders the input with its natural
+    representation and, only if that raises because the data is
+    heterogeneous, retries with each strategy the target language
+    supports in the order configured by the
+    ``literalizer_heterogeneous_strategy_precedence`` config value
+    (default: ``record``, ``tuple``, ``tagged_enum``, ``object_variant``,
+    ``variant``, ``union_type``, ``interface``).  This keeps homogeneous
+    and genuinely map-shaped data in its native form while still
+    representing record-shaped or mixed-scalar inputs.
+
+    ``:skip-if-unrepresentable:`` makes the directive emit no node at all
+    (instead of failing the build) when the input cannot be represented
+    in the target language -- including after ``auto`` exhausts its
+    precedence -- so a per-language loop can skip the languages a given
+    input does not fit without leaking data-shape concerns into prose.
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
@@ -670,10 +828,6 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
 
         language_name: str = self.options["language"]
         language_cls = _language_types()[language_name]
-        language_spec = self._build_language(
-            language_name=language_name,
-            language_cls=language_cls,
-        )
 
         pre_indent_level: int = self.options.get("pre-indent-level", 0)
         include_delimiters: bool = "include-delimiters" in self.options
@@ -688,9 +842,12 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         collection_layout = self._resolve_collection_layout()
 
         input_format = self._resolve_input_format(data_path=data_path)
-        with _literalize_errors_as_extension_errors():
-            result = literalize(
-                source=data_path.read_text(encoding="utf-8"),
+        source = data_path.read_text(encoding="utf-8")
+
+        def _do(language_spec: Language) -> LiteralizeResult:
+            """Render *source* with the built language."""
+            return literalize(
+                source=source,
                 input_format=input_format,
                 language=language_spec,
                 pre_indent_level=pre_indent_level,
@@ -701,6 +858,15 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
                 ref_key=ref_key,
                 collection_layout=collection_layout,
             )
+
+        rendered = self._render_with_strategy(
+            language_name=language_name,
+            language_cls=language_cls,
+            render=_do,
+        )
+        if rendered is None:
+            return []
+        result, _ = rendered
         parts: list[str] = []
         if include_preamble and result.preamble:
             parts.append("\n".join(result.preamble))
@@ -748,6 +914,8 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :record-shape-names: x,y=Point; a,b,c=Vec3
            :consumable-refs: my_var,other_var
            :collection-layout: multiline
+           :heterogeneous-strategy: auto
+           :skip-if-unrepresentable:
            :variable-name: my_data
            :existing-variable:
            :modifiers: public,static
@@ -852,10 +1020,6 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
         language_name: str = self.options["language"]
         language_cls = _language_types()[language_name]
-        language_spec = self._build_language(
-            language_name=language_name,
-            language_cls=language_cls,
-        )
 
         pre_indent_level: int = self.options.get("pre-indent-level", 0)
         include_preamble: bool = "include-preamble" in self.options
@@ -891,31 +1055,44 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         comment_source = self._resolve_comment_source()
 
         input_format = self._resolve_input_format(data_path=data_path)
+        source = data_path.read_text(encoding="utf-8")
+
+        def _do(language_spec: Language) -> LiteralizeResult:
+            """Render the calls for *source* with the built language."""
+            return literalize_call(
+                source=source,
+                input_format=input_format,
+                language=language_spec,
+                target_function=target_function,
+                parameter_names=parameter_names,
+                call_transform=call_transform,
+                zip_source=zip_source,
+                zip_input_format=zip_input_format,
+                comment_source=comment_source,
+                per_element=per_element,
+                ref_case=ref_case,
+                consumable_refs=consumable_refs,
+                ref_key=ref_key,
+                collection_layout=collection_layout,
+                variable_form=variable_form,
+            )
+
         try:
-            with _literalize_errors_as_extension_errors():
-                result = literalize_call(
-                    source=data_path.read_text(encoding="utf-8"),
-                    input_format=input_format,
-                    language=language_spec,
-                    target_function=target_function,
-                    parameter_names=parameter_names,
-                    call_transform=call_transform,
-                    zip_source=zip_source,
-                    zip_input_format=zip_input_format,
-                    comment_source=comment_source,
-                    per_element=per_element,
-                    ref_case=ref_case,
-                    consumable_refs=consumable_refs,
-                    ref_key=ref_key,
-                    collection_layout=collection_layout,
-                    variable_form=variable_form,
-                )
+            rendered = self._render_with_strategy(
+                language_name=language_name,
+                language_cls=language_cls,
+                render=_do,
+            )
         except ParameterCountMismatchError as exc:
             msg = (
                 f"':parameter-names:' has {len(parameter_names)} entries "
                 f"but the data provides a different number of values: {exc}"
             )
             raise ExtensionError(message=msg) from exc
+
+        if rendered is None:
+            return []
+        result, language_spec = rendered
 
         code = result.code
         if pre_indent_level > 0:
@@ -945,6 +1122,12 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_directive(
         name="literalizer-call",
         cls=LiteralizerCallDirective,
+    )
+    app.add_config_value(
+        name="literalizer_heterogeneous_strategy_precedence",
+        default=list(_DEFAULT_HETEROGENEOUS_STRATEGY_PRECEDENCE),
+        rebuild="env",
+        types=frozenset({list, tuple}),
     )
     return {
         "version": version(distribution_name="sphinx-literalizer"),

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -238,8 +238,8 @@ _AUTO_STRATEGY = "auto"
 # strategies *after* the natural representation fails.  Restricted per
 # directive to the strategies the target language actually exposes;
 # overridable via the ``literalizer_heterogeneous_strategy_precedence``
-# config value.  ``error`` is never a fallback -- it is the failure that
-# ``auto`` is recovering from.
+# configuration value.  ``error`` is never a fallback -- it is the
+# failure that ``auto`` is recovering from.
 _DEFAULT_HETEROGENEOUS_STRATEGY_PRECEDENCE: tuple[str, ...] = (
     "record",
     "tuple",
@@ -703,42 +703,46 @@ class _BaseLiteralizerDirective(SphinxDirective):
         target language and ``:skip-if-unrepresentable:`` is set (the
         caller then emits no node).
         """
-        hs_value: str | None = self.options.get("heterogeneous-strategy")
         skip = "skip-if-unrepresentable" in self.options
 
-        if hs_value == _AUTO_STRATEGY:
+        if self.options.get("heterogeneous-strategy") == _AUTO_STRATEGY:
             attempts: list[str | None] = [
                 None,
                 *self._auto_precedence(language_cls=language_cls),
             ]
         else:
-            attempts = [hs_value]
+            attempts = [self.options.get("heterogeneous-strategy")]
 
-        for index, strategy_value in enumerate(iterable=attempts):
-            is_last = index == len(attempts) - 1
-            language_spec = self._build_language(
+        def _build(strategy_value: str | None) -> Language:
+            """Build the language for one attempt's strategy."""
+            return self._build_language(
                 language_name=language_name,
                 language_cls=language_cls,
                 heterogeneous_strategy_value=strategy_value,
             )
-            try:
-                return render(language_spec), language_spec
-            except HeterogeneousCollectionError as exc:
-                if hs_value == _AUTO_STRATEGY and not is_last:
+
+        with _literalize_errors_as_extension_errors():
+            for strategy_value in attempts:
+                try:
+                    language_spec = _build(strategy_value=strategy_value)
+                    return render(language_spec), language_spec
+                except UnrepresentableInputError:
+                    # No heterogeneous strategy can fix a shape-level
+                    # rejection, so do not fall back; skip or surface it.
+                    if skip:
+                        return None
+                    raise
+                except HeterogeneousCollectionError:
+                    # An ``auto`` fallback (or the sole attempt): move on
+                    # to the next strategy, if any.
                     continue
-                if skip:
-                    return None
-                raise ExtensionError(message=str(object=exc)) from exc
-            except UnrepresentableInputError as exc:
-                if skip:
-                    return None
-                raise ExtensionError(message=str(object=exc)) from exc
-            except _USER_FACING_LITERALIZER_ERRORS as exc:
-                raise ExtensionError(message=str(object=exc)) from exc
-        # ``attempts`` is always non-empty, so the loop always returns or
-        # raises; this is unreachable and only satisfies the type checker.
-        msg = "no heterogeneous strategy produced a result"
-        raise ExtensionError(message=msg)
+            # Every attempt raised ``HeterogeneousCollectionError``.
+            if skip:
+                return None
+            # Re-run the last attempt so its error propagates to the
+            # surrounding converter as a clean ``ExtensionError``.
+            language_spec = _build(strategy_value=attempts[-1])
+            return render(language_spec), language_spec
 
 
 @beartype
@@ -797,7 +801,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
     representation and, only if that raises because the data is
     heterogeneous, retries with each strategy the target language
     supports in the order configured by the
-    ``literalizer_heterogeneous_strategy_precedence`` config value
+    ``literalizer_heterogeneous_strategy_precedence`` configuration value
     (default: ``record``, ``tuple``, ``tagged_enum``, ``object_variant``,
     ``variant``, ``union_type``, ``interface``).  This keeps homogeneous
     and genuinely map-shaped data in its native form while still

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7190,3 +7190,112 @@ def test_heterogeneous_strategy_auto_literalizer_call_rust(
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
     assert literal_block.astext() == "add(1, 2);\nadd(3, 4);"
     app.cleanup()
+
+
+def test_skip_if_unrepresentable_unrepresentable_input_csharp(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:skip-if-unrepresentable: also covers shape-level rejections
+    (UnrepresentableInputError), not just heterogeneous collections.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(data="1: a\n2: b\n")
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: csharp
+           :skip-if-unrepresentable:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    assert list(doctree.findall(condition=nodes.literal_block)) == []
+    app.cleanup()
+
+
+def test_unrepresentable_input_without_skip_raises_csharp(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A shape-level rejection without :skip-if-unrepresentable: fails
+    the build with a clean ExtensionError.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(data="1: a\n2: b\n")
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: csharp
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(expected_exception=ExtensionError):
+        app.build()
+
+
+def test_skip_if_unrepresentable_literalizer_call_csharp(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:skip-if-unrepresentable: makes literalizer-call emit no node
+    when the call data cannot be represented in the language.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(data="- {1: a, 2: b}\n")
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.yaml
+           :language: csharp
+           :target-function: f
+           :parameter-names: m
+           :per-element:
+           :skip-if-unrepresentable:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    assert list(doctree.findall(condition=nodes.literal_block)) == []
+    app.cleanup()

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6775,3 +6775,418 @@ def test_heterogeneous_strategy_tuple_rust(
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
     assert literal_block.astext() == '(\n    1,\n    true,\n    "x",\n)'
     app.cleanup()
+
+
+def test_heterogeneous_strategy_auto_keeps_homogeneous_output_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The auto mode leaves homogeneous data in its natural
+    representation instead of converting it to a generated record.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"a": 1}, {"a": 2}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: auto
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        'HashMap::from([("a", 1)]),\nHashMap::from([("a", 2)]),'
+    )
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_auto_keeps_map_shape_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The auto mode keeps a genuinely map-shaped mapping as a native
+    map rather than promoting it to a record (the core #199 concern).
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"k1": 1, "k2": 2}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: auto
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == '("k1", 1),\n("k2", 2),'
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_auto_falls_back_to_record_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The auto mode falls back to record for a record-shaped dict that
+    the natural representation cannot hold in a strict-map language.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"id": 1, "desc": "x", "blocks": [1, 2]}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: auto
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        'Record0 { id: 1, desc: "x", blocks: vec![1, 2] },'
+    )
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_auto_default_precedence_prefers_tuple_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """With the default precedence, auto skips record (which cannot
+    represent a mixed-scalar list) and uses tuple.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, "hello"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: auto
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == '1,\n"hello",'
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_auto_precedence_config_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The precedence config value reorders the strategies auto tries,
+    so the same input renders differently.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, "hello"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: auto
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={
+            "extensions": ["sphinx_literalizer"],
+            "literalizer_heterogeneous_strategy_precedence": [
+                "tagged_enum",
+                "tuple",
+            ],
+        },
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        "enum Value {\n"
+        "    I32(i32),\n"
+        "    Str(&'static str),\n"
+        "}\n"
+        "\n"
+        'Value::I32(1),\nValue::Str("hello"),'
+    )
+    app.cleanup()
+
+
+def test_concrete_heterogeneous_strategy_unrepresentable_extension_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A concrete (non-auto) strategy that cannot represent the input
+    surfaces as a clean ExtensionError, not a traceback.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"id": 1, "desc": "x", "blocks": [1, 2]}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: tagged_enum
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(expected_exception=ExtensionError):
+        app.build()
+
+
+def test_skip_if_unrepresentable_emits_no_node_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """:skip-if-unrepresentable: emits no node (instead of failing the
+    build) when the input cannot be represented in the language.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, "hello"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :skip-if-unrepresentable:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    assert list(doctree.findall(condition=nodes.literal_block)) == []
+    app.cleanup()
+
+
+def test_unrepresentable_without_skip_raises_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Without :skip-if-unrepresentable: an unrepresentable input still
+    fails the build with a clean ExtensionError.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, "hello"]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(expected_exception=ExtensionError):
+        app.build()
+
+
+def test_skip_if_unrepresentable_after_auto_exhausts_precedence_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """When auto exhausts the configured precedence without representing
+    the input, :skip-if-unrepresentable: emits no node.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"a": 1, "b": [1, "x"]}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: auto
+           :skip-if-unrepresentable:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={
+            "extensions": ["sphinx_literalizer"],
+            "literalizer_heterogeneous_strategy_precedence": [
+                "record",
+                "tagged_enum",
+            ],
+        },
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    assert list(doctree.findall(condition=nodes.literal_block)) == []
+    app.cleanup()
+
+
+def test_heterogeneous_strategy_auto_literalizer_call_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The auto mode integrates with literalizer-call: homogeneous call
+    data keeps its natural rendering.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[[1, 2], [3, 4]]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: rust
+           :target-function: add
+           :parameter-names: a,b
+           :per-element:
+           :heterogeneous-strategy: auto
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == "add(1, 2);\nadd(3, 4);"
+    app.cleanup()


### PR DESCRIPTION
Implements issue #199. Adds an `auto` heterogeneous strategy that renders the input with its natural representation first — so homogeneous and genuinely map-shaped data keep their native form — and only falls back through a configurable precedence (`literalizer_heterogeneous_strategy_precedence`, a new Sphinx config value) of language-supported strategies when the data is genuinely heterogeneous, removing the need to pick a single per-project or per-input strategy. Also adds a `:skip-if-unrepresentable:` flag on both directives that emits no node instead of failing the build when an input cannot be represented in the target language (including after `auto` exhausts its precedence), and surfaces `HeterogeneousCollectionError` from a concrete strategy as a clean `ExtensionError` rather than a traceback. The directives were refactored to build the language through a shared retry helper used by both `literalizer` and `literalizer-call`. Includes 10 new tests (155 pass, no regressions), CHANGELOG and docs updates (option reference, a new Configuration section, and `auto`/skip sections in the heterogeneous-strategies guide), and two spelling-dictionary additions. The strict `-W` docs build, ruff, and mypy all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes directive rendering/error-handling behavior by adding a retry loop and conditional node suppression, which can alter generated output and build results across languages. Risk is mitigated by extensive new tests but affects core directive execution paths.
> 
> **Overview**
> Adds ``:heterogeneous-strategy: auto`` to both directives, which first attempts the language’s natural rendering and then falls back through a configurable per-language precedence (new Sphinx config ``literalizer_heterogeneous_strategy_precedence``) until a strategy can represent the input.
> 
> Introduces a ``:skip-if-unrepresentable:`` flag that makes ``literalizer``/``literalizer-call`` emit no node (instead of failing the build) when inputs are not representable, including after ``auto`` exhausts fallbacks, and surfaces ``HeterogeneousCollectionError`` from concrete strategies as clean ``ExtensionError``s.
> 
> Refactors directive internals to share strategy-attempt/retry logic, updates docs/changelog, and adds a comprehensive test suite covering ``auto`` behavior, precedence configuration, and skipping semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418645734991130ef3f9563eea3a9635c34c9ab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->