### PR TITLE
Default :heterogeneous-strategy: to auto (#213)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ Next
 ----
 
 
+- ``:heterogeneous-strategy:`` now defaults to ``auto`` instead of
+  falling through to literalizer's per-language default (e.g. ``error``
+  for Rust).  ``auto`` renders the input with its natural representation
+  first -- so homogeneous and genuinely map-shaped data render
+  identically to before -- and genuinely unrepresentable input still
+  raises, so this only ever turns a representable input that previously
+  broke the build into a representable one.  Projects that forced
+  ``auto`` globally via a directive subclass in ``conf.py`` can drop
+  that override.  ``auto`` makes a representation choice implicitly
+  (``record`` vs ``tuple`` vs ``tagged_enum`` changes the generated
+  API), so set ``:heterogeneous-strategy:`` explicitly -- including
+  ``:heterogeneous-strategy: error`` to keep a mixed-scalar collection a
+  hard build failure -- when a specific behavior is wanted.
 - The documentation examples now use ``sphinx-toolbox``'s
   ``rest-example`` directive, which executes each ``literalizer`` and
   ``literalizer-call`` directive at build time, so the rendered output

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -9,26 +9,30 @@ Dynamically typed source data routinely contains such collections, but many targ
 The ``:heterogeneous-strategy:`` option (on both the ``literalizer`` and ``literalizer-call`` directives -- see :doc:`index`) selects how |project| renders these collections.
 This page explains what each strategy emits, when each is appropriate, and which languages expose which strategies.
 
-The default: ``error``
-----------------------
+The default: ``auto``
+---------------------
 
-Every language defaults to ``error``: a collection that mixes scalar types raises rather than emitting a literal that would not compile.
-This is deliberate -- silently coercing ``1`` and ``"hello"`` to a common type would change the data.
-The remaining strategies are opt-in, language-specific ways to represent the mixed collection faithfully instead of failing.
+``:heterogeneous-strategy:`` defaults to ``auto``.
+``auto`` renders the input with its natural representation first -- so homogeneous and genuinely map-shaped data keep their native form, byte-identical to naming no strategy at all -- and only falls back to a representational strategy when the natural rendering fails because the data is heterogeneous.
+Genuinely unrepresentable input still raises after the fallbacks are exhausted, so the "fail loud" safety is preserved exactly where it matters.
 
-The directive:
+``auto`` makes a representation choice implicitly: ``record`` vs ``tuple`` vs ``tagged_enum`` changes the shape of the generated API.
+An author who wants a specific representation for pedagogical or clarity reasons should set ``:heterogeneous-strategy:`` explicitly rather than rely on the default.
+To keep a mixed-scalar collection a hard build failure instead, set ``:heterogeneous-strategy: error`` explicitly:
 
 .. code-block:: rst
 
    .. literalizer:: data.json
       :language: rust
+      :heterogeneous-strategy: error
 
 with ``data.json`` containing ``[1, "hello"]`` raises an ``ExtensionError`` describing the heterogeneous scalar types.
+Without that explicit ``error``, the same input falls back through the configured precedence under ``auto``.
 
 Choosing a strategy
 -------------------
 
-``auto``
+``auto`` (the default)
    Let |project| choose.
    The input is rendered with its natural representation first, so homogeneous and genuinely map-shaped data keep their native form, and a strategy is only applied if that natural rendering fails because the data is heterogeneous.
    See `Letting the directive choose: auto`_ below.
@@ -36,6 +40,7 @@ Choosing a strategy
 ``error``
    Keep strict typing.
    Appropriate when mixed-scalar collections in the source data are a mistake you want surfaced rather than rendered.
+   This was the default before |project| defaulted ``:heterogeneous-strategy:`` to ``auto``; it must now be set explicitly.
 
 ``tagged_enum`` / ``object_variant`` / ``union_type`` / ``interface`` / ``variant``
    Wrap each value in a generated sum type so a *list* (or list-shaped mapping) of mixed scalars round-trips.
@@ -197,9 +202,9 @@ renders (no preamble -- the tuple is a native literal):
 Per-language support
 --------------------
 
-``error`` is available for every language and is always the default.
+``error`` is available for every language; ``auto`` is the default.
 The table below lists the additional strategies each language exposes.
-Languages not listed support only ``error``.
+Languages not listed support only ``error`` (set explicitly) and ``auto`` (which, with no representational strategy to fall back to, behaves like ``error`` for heterogeneous input).
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -454,11 +454,13 @@ Directive options
    ``error``
       Raise an error on empty keys.  Available for R.
 
-``:heterogeneous-strategy:`` (optional)
+``:heterogeneous-strategy:`` (optional, defaults to ``auto``)
    How to render scalar collections whose elements have more than one
-   language-level type.  Supported values:
+   language-level type.  Defaults to ``auto``; set it explicitly only
+   to pin a specific representation (see the caveat under ``auto``).
+   Supported values:
 
-   ``auto``
+   ``auto`` (default)
       Render the input with its natural representation first, and only
       if that fails because the data is heterogeneous, retry with each
       strategy the target language supports in the order given by the
@@ -467,9 +469,15 @@ Directive options
       Homogeneous and genuinely map-shaped data keep their native form,
       so a single ``auto`` works across a mix of inputs without picking
       a strategy per project or per file.
+      Because ``auto`` chooses a representation implicitly -- ``record``
+      vs ``tuple`` vs ``tagged_enum`` changes the shape of the
+      generated API -- set ``:heterogeneous-strategy:`` explicitly when
+      a specific representation is wanted for clarity.
    ``error``
-      Raise an error when a collection mixes scalar types (default for
-      all languages).
+      Raise an error when a collection mixes scalar types.  This was the
+      default before |project| defaulted ``:heterogeneous-strategy:`` to
+      ``auto``; set it explicitly to keep a mixed-scalar collection a
+      hard build failure.
    ``tagged_enum``
       Emit a minimal tagged ``enum`` in the preamble and wrap each
       heterogeneous value at the call site (e.g. ``Value::I32(1)``).

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -705,13 +705,25 @@ class _BaseLiteralizerDirective(SphinxDirective):
         """
         skip = "skip-if-unrepresentable" in self.options
 
-        if self.options.get("heterogeneous-strategy") == _AUTO_STRATEGY:
+        # An unset ``:heterogeneous-strategy:`` defaults to ``auto``
+        # rather than falling through to literalizer's per-language
+        # default (e.g. ``error`` for Rust): ``auto`` strictly dominates
+        # ``error`` as a default since it tries the natural
+        # representation first (byte-identical output for homogeneous /
+        # map-shaped data) and still raises for genuinely
+        # unrepresentable input.  An author who wants a specific
+        # representation sets the option explicitly.
+        strategy = self.options.get(
+            "heterogeneous-strategy",
+            _AUTO_STRATEGY,
+        )
+        if strategy == _AUTO_STRATEGY:
             attempts: list[str | None] = [
                 None,
                 *self._auto_precedence(language_cls=language_cls),
             ]
         else:
-            attempts = [self.options.get("heterogeneous-strategy")]
+            attempts = [strategy]
 
         def _build(strategy_value: str | None) -> Language:
             """Build the language for one attempt's strategy."""

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7037,6 +7037,11 @@ def test_skip_if_unrepresentable_emits_no_node_rust(
 ) -> None:
     """:skip-if-unrepresentable: emits no node (instead of failing the
     build) when the input cannot be represented in the language.
+
+    ``:heterogeneous-strategy: error`` is set explicitly because the
+    default is now ``auto``, under which ``[1, "hello"]`` is
+    representable (as a tuple); ``error`` keeps it a hard failure so the
+    skip flag has something to skip.
     """
     source_directory = tmp_path / "source"
     source_directory.mkdir()
@@ -7052,6 +7057,7 @@ def test_skip_if_unrepresentable_emits_no_node_rust(
 
         .. literalizer:: data.json
            :language: rust
+           :heterogeneous-strategy: error
            :skip-if-unrepresentable:
     """
         )
@@ -7076,6 +7082,10 @@ def test_unrepresentable_without_skip_raises_rust(
 ) -> None:
     """Without :skip-if-unrepresentable: an unrepresentable input still
     fails the build with a clean ExtensionError.
+
+    ``:heterogeneous-strategy: error`` is set explicitly because the
+    default is now ``auto``, under which ``[1, "hello"]`` is
+    representable (as a tuple) and would not fail the build.
     """
     source_directory = tmp_path / "source"
     source_directory.mkdir()
@@ -7091,6 +7101,7 @@ def test_unrepresentable_without_skip_raises_rust(
 
         .. literalizer:: data.json
            :language: rust
+           :heterogeneous-strategy: error
     """
         )
     )
@@ -7189,6 +7200,91 @@ def test_heterogeneous_strategy_auto_literalizer_call_rust(
     doctree = app.env.get_doctree(docname="index")
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
     assert literal_block.astext() == "add(1, 2);\nadd(3, 4);"
+    app.cleanup()
+
+
+def test_unset_heterogeneous_strategy_defaults_to_auto_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """An unset :heterogeneous-strategy: defaults to ``auto`` rather
+    than falling through to literalizer's per-language default
+    (``error`` for Rust): a record-shaped heterogeneous dict falls back
+    to ``record`` instead of failing the build.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"id": 1, "desc": "x", "blocks": [1, 2]}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        'Record0 { id: 1, desc: "x", blocks: vec![1, 2] },'
+    )
+    app.cleanup()
+
+
+def test_unset_heterogeneous_strategy_keeps_homogeneous_output_rust(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Defaulting to ``auto`` leaves homogeneous data byte-identical to
+    the pre-default behavior: the natural ``HashMap`` rendering is used
+    with no fallback applied.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"a": 1}, {"a": 2}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        'HashMap::from([("a", 1)]),\nHashMap::from([("a", 2)]),'
+    )
     app.cleanup()
 
 


### PR DESCRIPTION
Closes #213. An unset `:heterogeneous-strategy:` now resolves to `auto` instead of falling through to literalizer's per-language default (e.g. `error` for Rust), so heterogeneous-but-representable fixtures no longer break the build while homogeneous/map-shaped data renders identically to before and genuinely unrepresentable input still raises. `auto` makes an implicit representation choice, so `:heterogeneous-strategy: error` must now be set explicitly to force a hard failure (and authors wanting a specific representation should still pin it). Docs (index, heterogeneous-strategies page), CHANGELOG, and tests were updated, including two `:skip-if-unrepresentable:` tests pinned to explicit `error` since their `[1, "hello"]` input is now representable under the new default. All 160 extension tests pass and the docs build cleanly with `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a directive default that affects generated output and build-failure behavior, which could subtly alter rendered APIs for heterogeneous inputs if projects relied on implicit per-language defaults. Impact is largely constrained to documentation/code generation, with tests updated to cover the new default.
> 
> **Overview**
> **Default behavior change:** when `:heterogeneous-strategy:` is omitted, directives now treat it as `auto` (rather than deferring to each language’s default such as Rust’s `error`), so heterogeneous-but-representable inputs are rendered via `auto` fallbacks instead of breaking builds.
> 
> **Docs/tests updates:** documentation and changelog are updated to describe the new default and the need to set `:heterogeneous-strategy: error` explicitly to keep strict failure semantics, and extension tests are adjusted/added to pin `error` where required and to assert the new default preserves byte-identical output for homogeneous data while enabling fallbacks for heterogeneous Rust inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01aa318219530785253f7669ae2763b2e2718a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->