### PR TITLE
Bump literalizer to 2026.5.17

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,25 @@ Next
 ----
 
 
+- Bumped ``literalizer`` to ``2026.5.17``.
+- ``:variable-name:`` (with ``:existing-variable:``) on
+  ``literalizer-call`` now produces a call-result binding for ``ada``,
+  ``bash``, ``c``, ``d``, ``elixir``, ``erlang``, ``forth``,
+  ``fortran``, ``nim``, ``objectivec``, ``systemverilog``, ``tcl``, and
+  ``zig``.
+  These languages previously failed the build because they could not
+  bind a call result; they now emit an idiomatic binding (for example
+  ``set my_data [make_widget ...]`` for ``tcl`` and ``auto my_data =
+  make_widget(...);`` for ``d``), following upstream ``literalizer``
+  extending ``variable_form`` to those languages.
+  No directive change was needed.
+- ``:heterogeneous-strategy: record`` (including the ``auto`` default's
+  ``record`` fallback) and ``:record-struct-name-prefix:`` now work for
+  ``c``, ``csharp``, ``cpp``, ``crystal``, ``d``, ``nim``, ``odin``,
+  ``swift``, ``v``, and ``zig``.
+  This follows upstream ``literalizer`` adding the ``RECORD`` strategy
+  to those languages; the directives expose it generically from the
+  per-language capability flags, so no directive change was needed.
 - ``:heterogeneous-strategy:`` now defaults to ``auto`` instead of
   falling through to literalizer's per-language default (e.g. ``error``
   for Rust).  ``auto`` renders the input with its natural representation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.16.1",
+    "literalizer==2026.5.17",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7395,3 +7395,145 @@ def test_skip_if_unrepresentable_literalizer_call_csharp(
     doctree = app.env.get_doctree(docname="index")
     assert list(doctree.findall(condition=nodes.literal_block)) == []
     app.cleanup()
+
+
+def test_literalizer_call_variable_name_tcl(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:variable-name:`` binds a ``literalizer-call`` result for a
+    language that gained call-variable-binding in ``literalizer``
+    ``2026.5.17`` (Tcl).
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"count": 42}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: tcl
+           :target-function: make_widget
+           :parameter-names: count
+           :variable-name: my_data
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    expected = 'set my_data [make_widget [dict create "count" 42]]'
+    assert text == expected
+    app.cleanup()
+
+
+def test_literalizer_call_existing_variable_d(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:existing-variable:`` binds a ``literalizer-call`` result
+    without a declaration keyword for a language that gained
+    call-variable-binding in ``literalizer`` ``2026.5.17`` (D).
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"count": 42}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: d
+           :target-function: make_widget
+           :parameter-names: count
+           :variable-name: my_data
+           :existing-variable:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    expected = 'my_data = make_widget(JSONValue(["count": JSONValue(42)]));'
+    assert text == expected
+    app.cleanup()
+
+
+def test_record_struct_name_prefix_swift(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Swift's :heterogeneous-strategy: record honours
+    :record-struct-name-prefix:, exercising the ``RECORD`` strategy
+    ``literalizer`` ``2026.5.17`` added for Swift.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"x": 1, "y": 2}, {"x": 3, "y": 4}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: swift
+           :heterogeneous-strategy: record
+           :record-struct-name-prefix: Row
+           :include-delimiters:
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        "struct Row0 { let x: Int; let y: Int }\n"
+        "\n"
+        "[\n"
+        "    Row0(x: 1, y: 2),\n"
+        "    Row0(x: 3, y: 4),\n"
+        "]"
+    )
+    app.cleanup()

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.16.1"
+version = "2026.5.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -770,9 +770,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/833180d657d0356b583823f52378cb60e450d56447b9168cc05dc5ea50cc/literalizer-2026.5.16.1.tar.gz", hash = "sha256:96b4dbf18783d22154247c219a0cb0cada1eaf01bfbb8de71903d3a7dc4f8ec0", size = 2674536, upload-time = "2026-05-16T19:22:59.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2f/eca4642d193c0de5daef2f61b3f239106936de68b09f6563f083286381a7/literalizer-2026.5.17.tar.gz", hash = "sha256:e2fd8bc64eb11f115c540378de278664cd66f4e8ad68799172a6dfba77f17ff5", size = 2775902, upload-time = "2026-05-17T12:14:52.669Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/b0/28b8d25083c8bdcf357789f1bbe6e86f72e48ba3d49f6fc3e1fc6cb29c70/literalizer-2026.5.16.1-py3-none-any.whl", hash = "sha256:f10cff05c51a5927bb4623ae82514e7e9219d81d16402e04906de34f00dc6646", size = 630550, upload-time = "2026-05-16T19:22:57.616Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/4c/fcd3e385b8a6ee378b8cb0fad4bc986fe6b295793905eb61a6457dd6cb24/literalizer-2026.5.17-py3-none-any.whl", hash = "sha256:ab98ceeb0da2ff0c63e830fdb9e24a2207c88bbfdbfe7fdda14e4ba0b408f4e1", size = 677480, upload-time = "2026-05-17T12:14:50.362Z" },
 ]
 
 [[package]]
@@ -2067,7 +2067,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.16.1" },
+    { name = "literalizer", specifier = "==2026.5.17" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.0" },


### PR DESCRIPTION
Bumps `literalizer` 2026.5.16.1 → 2026.5.17 (`pyproject.toml` + `uv.lock`). The release is purely additive at the language level and the directives already expose these capabilities generically from per-language flags, so no extension source change was needed. `:variable-name:`/`:existing-variable:` on `literalizer-call` now produces a call-result binding for ada, bash, c, d, elixir, erlang, forth, fortran, nim, objectivec, systemverilog, tcl, and zig (previously a build failure), and `:heterogeneous-strategy: record` plus `:record-struct-name-prefix:` now work for c, csharp, cpp, crystal, d, nim, odin, swift, v, and zig. The CHANGELOG documents both newly-unlocked capabilities and three golden tests lock in the new behaviour. Full suite passes at 100% coverage and the docs build (`-W`, executing directives live) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump with additive behavior surfaced via existing directive options; main impact is changed generated output for newly-supported languages, covered by new golden tests.
> 
> **Overview**
> Bumps the pinned `literalizer` dependency to `2026.5.17` (including lockfile), which enables additional languages to support `literalizer-call` result bindings via `:variable-name:`/`:existing-variable:` and expands `:heterogeneous-strategy: record` plus `:record-struct-name-prefix:` support.
> 
> Adds three integration tests to lock in the new emitted code for Tcl call-result binding, D existing-variable assignment, and Swift `record` struct prefix behavior, and documents the newly-unlocked capabilities in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f7aaf0a95da1547a594a4d75cdcd5fdda4be472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->