### PR TITLE
Type format lookups as enum.Enum instead of object

### DIFF
--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -112,7 +112,7 @@ _COLLECTION_LAYOUT_VALUES: tuple[str, ...] = tuple(
 
 
 @cache
-def _all_formats() -> dict[str, dict[tuple[str, str], object]]:
+def _all_formats() -> dict[str, dict[tuple[str, str], enum.Enum]]:
     """Build format lookup dicts for all format options."""
     return {
         option_name: {
@@ -138,8 +138,8 @@ def _lookup_format(
     language_name: str,
     directive_name: str,
     format_value: str,
-    formats: dict[tuple[str, str], object],
-) -> object:
+    formats: dict[tuple[str, str], enum.Enum],
+) -> enum.Enum:
     """Look up a format enum member by language and value."""
     try:
         return formats[(language_name, format_value)]


### PR DESCRIPTION
Closes #217 (hole #3 of #216).

`_all_formats()` and `_lookup_format()` returned `object`, degrading format enum members to `object` before they were splatted into the language constructor; these are narrowed to `enum.Enum`, and the tighter type propagates automatically through `_apply_format_options` (no annotation change needed there). No behaviour change.

Verified with pyright (strict), pyrefly, ty (error-on-warning), mypy (the only mypy errors are pre-existing on `main`, confirmed via `git stash`, and don't touch the edited lines), and the full `pytest` suite (163 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens type annotations for format lookup helpers and should not affect runtime behavior.
> 
> **Overview**
> Tightens typing for format option resolution by changing `_all_formats()` and `_lookup_format()` to return `enum.Enum` members instead of `object`, improving static type checking where these values are passed into language constructors.
> 
> No functional behavior changes; the lookup logic and error handling remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190712fa302793d81e5552bb626f306b85c05a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->