### PR TITLE
Centralise string→enum option lookups in a typed helper (#218)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Changelog
 Next
 ----
 
+- The error raised for an unrecognized ``:modifiers:`` value is now
+  ``'<value>' is not a valid value. Choose from: ...`` (listing the
+  modifiers the target language supports), replacing the previous
+  ``Language '<name>' does not support modifier '<value>'.`` message.
+  A single shared helper now converts these string options to their
+  internal values and raises a clean ``ExtensionError`` instead of
+  relying on each option's input validator to constrain the value.
+
 2026.05.17
 ----------
 

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -151,8 +151,25 @@ def _lookup_format(
         raise ExtensionError(message=msg) from None
 
 
+@beartype
+def _enum_member[E: enum.Enum](cls: type[E], value: str) -> E:
+    """Look up an enum member by its case-insensitive name.
+
+    Raises a clean ``ExtensionError`` (rather than the ``KeyError`` from
+    a bare ``cls[value.upper()]``) when *value* is not a member name, so
+    callers need not rely on an upstream ``directives.choice`` validator
+    to constrain the string.
+    """
+    try:
+        return cls[value.upper()]
+    except KeyError:
+        choices = sorted(member.name.lower() for member in cls)
+        detail = f" Choose from: {', '.join(choices)}." if choices else ""
+        msg = f"'{value}' is not a valid value.{detail}"
+        raise ExtensionError(message=msg) from None
+
+
 def _parse_modifiers(
-    language_name: str,
     language_cls: LanguageCls,
     value: str,
 ) -> frozenset[enum.Enum]:
@@ -162,14 +179,7 @@ def _parse_modifiers(
         name = raw.strip()
         if not name:
             continue
-        try:
-            result.add(language_cls.Modifiers[name.upper()])
-        except KeyError:
-            msg = (
-                f"Language '{language_name}' does not support "
-                f"modifier '{name}'."
-            )
-            raise ExtensionError(message=msg) from None
+        result.add(_enum_member(cls=language_cls.Modifiers, value=name))
     return frozenset(result)
 
 
@@ -549,7 +559,7 @@ class _BaseLiteralizerDirective(SphinxDirective):
         """
         explicit = self.options.get(option_name)
         if explicit is not None:
-            return InputFormat[explicit.upper()]
+            return _enum_member(cls=InputFormat, value=explicit)
         suffix = data_path.suffix.lower()
         try:
             return _EXTENSION_TO_INPUT_FORMAT[suffix]
@@ -591,14 +601,13 @@ class _BaseLiteralizerDirective(SphinxDirective):
         ref_case: IdentifierCase | None = (
             None
             if ref_case_value is None
-            else IdentifierCase[ref_case_value.upper()]
+            else _enum_member(cls=IdentifierCase, value=ref_case_value)
         )
         ref_key: str = self.options.get("ref-key", "$ref")
         return ref_case, ref_key
 
     def _resolve_variable_form(
         self,
-        language_name: str,
         language_cls: LanguageCls,
         *,
         allow_both: bool,
@@ -642,7 +651,6 @@ class _BaseLiteralizerDirective(SphinxDirective):
             frozenset()
             if modifiers_value is None
             else _parse_modifiers(
-                language_name=language_name,
                 language_cls=language_cls,
                 value=modifiers_value,
             )
@@ -660,7 +668,10 @@ class _BaseLiteralizerDirective(SphinxDirective):
             "collection-layout",
             "compact",
         )
-        return CollectionLayout[collection_layout_value.upper()]
+        return _enum_member(
+            cls=CollectionLayout,
+            value=collection_layout_value,
+        )
 
     def _auto_precedence(self, *, language_cls: LanguageCls) -> list[str]:
         """Strategies ``auto`` falls back through, most preferred first.
@@ -849,7 +860,6 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         include_delimiters: bool = "include-delimiters" in self.options
         include_preamble: bool = "include-preamble" in self.options
         variable_form = self._resolve_variable_form(
-            language_name=language_name,
             language_cls=language_cls,
             allow_both=True,
         )
@@ -1051,7 +1061,6 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         ref_case, ref_key = self._resolve_ref_options()
         collection_layout = self._resolve_collection_layout()
         variable_form = self._resolve_variable_form(
-            language_name=language_name,
             language_cls=language_cls,
             allow_both=False,
         )

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1372,7 +1372,47 @@ def test_unsupported_modifier_error(
     )
     with pytest.raises(
         expected_exception=ExtensionError,
-        match=r"^Language 'python' does not support modifier 'public'\.$",
+        match=r"^'public' is not a valid value\.$",
+    ):
+        app.build()
+
+
+def test_unsupported_modifier_error_lists_choices(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """An unsupported modifier for a language that has modifiers lists
+    the valid choices in the error.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: java
+           :variable-name: myList
+           :modifiers: bogus
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"^'bogus' is not a valid value\. Choose from: "
+            r"final, private, protected, public, static\.$"
+        ),
     ):
         app.build()
 


### PR DESCRIPTION
Closes #218 (hole #4 of #216). Adds a generic `_enum_member[E: enum.Enum](cls, value) -> E` helper that raises a clean `ExtensionError` instead of `KeyError`, and routes the `InputFormat`, `IdentifierCase`, `CollectionLayout`, and per-language `Modifiers` lookups through it, removing the implicit coupling to the `directives.choice` validators. The unsupported-modifier error message changes to `'<value>' is not a valid value. Choose from: ...` (it deliberately omits the enum class name to avoid leaking internal names like `_JavaModifiers`); the asserting test is updated and a choices-listing test added. The now-unused `language_name` parameter that only threaded into `_parse_modifiers` is dropped. Verified with mypy, pyright, ty, pyrefly, ruff, vulture, the full pytest suite (164 passed, 100% line + branch coverage), and the CHANGELOG is updated under "Next".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of option-to-enum conversions with limited behavior change to user-facing error messages when invalid enum-like option values are provided.
> 
> **Overview**
> Centralizes case-insensitive string→enum lookups behind a new generic `_enum_member()` helper that raises a clean `ExtensionError` (instead of leaking `KeyError`), and routes `InputFormat`, `IdentifierCase`, `CollectionLayout`, and per-language `Modifiers` parsing through it.
> 
> Changes the invalid `:modifiers:` error from *“Language 'X' does not support modifier 'Y'”* to *`'<value>' is not a valid value. Choose from: ...`* (when choices exist), updates/adds tests accordingly, and documents the new behavior in `CHANGELOG.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3beccfee6cba1c5aa53ba3a19187ed08c2984e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->