### PR TITLE
Bump literalizer to 2026.5.17.1 and honour :wrap-in-file: on literalizer-call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Next
   internal values and raises a clean ``ExtensionError`` instead of
   relying on each option's input validator to constrain the value.
 - Bumped ``literalizer`` to ``2026.5.17.1``.
-- ``:wrap-in-file:`` is now honoured by the ``literalizer-call``
+- ``:wrap-in-file:`` is now honored by the ``literalizer-call``
   directive.
   It was previously parsed (and documented as a shared option) but
   silently ignored, so ``literalizer-call`` always emitted bare calls.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,22 @@ Next
   A single shared helper now converts these string options to their
   internal values and raises a clean ``ExtensionError`` instead of
   relying on each option's input validator to constrain the value.
+- Bumped ``literalizer`` to ``2026.5.17.1``.
+- ``:wrap-in-file:`` is now honoured by the ``literalizer-call``
+  directive.
+  It was previously parsed (and documented as a shared option) but
+  silently ignored, so ``literalizer-call`` always emitted bare calls.
+  It now passes ``wrap_in_file`` through to ``literalize_call``, which
+  upstream ``2026.5.17.1`` extended to render a complete, self-contained
+  file: an injected no-op stub for the target function (and any declared
+  refs) precedes the generated calls, with a single reconciled preamble.
+- C# array sequence-format output no longer carries a spurious ``using
+  System;`` / ``using System.Collections.Generic;`` line, and the empty
+  array form is now the typed literal ``new T[] {}`` rather than
+  ``Array.Empty<T>()``, following upstream ``literalizer``
+  ``2026.5.17.1``.
+  No directive change was needed; rendered C# array examples update
+  automatically.
 
 2026.05.17
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.17",
+    "literalizer==2026.5.17.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -1263,6 +1263,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             p.strip() for p in options.parameter_names.split(sep=",")
         ]
         per_element = options.per_element
+        wrap_in_file = options.wrap_in_file
 
         call_transform = self._build_call_transform(options=options)
 
@@ -1309,6 +1310,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
                 zip_input_format=zip_input_format,
                 comment_source=comment_source,
                 per_element=per_element,
+                wrap_in_file=wrap_in_file,
                 ref_case=ref_case,
                 consumable_refs=consumable_refs,
                 ref_key=ref_key,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7528,6 +7528,60 @@ def test_literalizer_call_existing_variable_d(
     app.cleanup()
 
 
+def test_literalizer_call_wrap_in_file(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:wrap-in-file:`` on ``literalizer-call`` renders a complete,
+    self-contained file: an injected no-op stub for the target function
+    precedes the generated calls.
+
+    This exercises ``literalizer`` ``2026.5.17.1``'s self-contained
+    ``literalize_call`` file mode (previously ``:wrap-in-file:`` was
+    parsed but silently ignored by ``literalizer-call``).
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[1, 2]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: make_widget
+           :parameter-names: count
+           :per-element:
+           :wrap-in-file:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    expected = (
+        "def make_widget(*_args: object, **_kwargs: object) -> object: ...\n"
+        "make_widget(count=1)\n"
+        "make_widget(count=2)"
+    )
+    assert text == expected
+    app.cleanup()
+
+
 def test_record_struct_name_prefix_swift(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.17"
+version = "2026.5.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -770,9 +770,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/2f/eca4642d193c0de5daef2f61b3f239106936de68b09f6563f083286381a7/literalizer-2026.5.17.tar.gz", hash = "sha256:e2fd8bc64eb11f115c540378de278664cd66f4e8ad68799172a6dfba77f17ff5", size = 2775902, upload-time = "2026-05-17T12:14:52.669Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/25/106fc073ed2920cee751e66f4325da6dfa6b2464f9cc78decbc935d62135/literalizer-2026.5.17.1.tar.gz", hash = "sha256:22025b03be1e7bd4aa4e6b2b9271cc3cd7137cf97c99a655cf184e073e289aaf", size = 2830505, upload-time = "2026-05-17T16:17:17.101Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/4c/fcd3e385b8a6ee378b8cb0fad4bc986fe6b295793905eb61a6457dd6cb24/literalizer-2026.5.17-py3-none-any.whl", hash = "sha256:ab98ceeb0da2ff0c63e830fdb9e24a2207c88bbfdbfe7fdda14e4ba0b408f4e1", size = 677480, upload-time = "2026-05-17T12:14:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fb/6c9d60c36cb425a665235c61db9972c8336ddaaa6785ce4c341280f8fa19/literalizer-2026.5.17.1-py3-none-any.whl", hash = "sha256:98fe89107868a7d27462fdb0315ca646e993758842ec7bf69c9ede1655165ed8", size = 679691, upload-time = "2026-05-17T16:17:15.486Z" },
 ]
 
 [[package]]
@@ -2067,7 +2067,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.17" },
+    { name = "literalizer", specifier = "==2026.5.17.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.0" },


### PR DESCRIPTION
Bumps the pinned `literalizer` dependency to `2026.5.17.1` and makes use of the new upstream behaviour.

The `literalizer-call` directive now passes `wrap_in_file` through to `literalize_call`: `:wrap-in-file:` was documented as a shared option and parsed, but silently ignored, so `literalizer-call` always emitted bare calls. Upstream `2026.5.17.1` extended `literalize_call`'s `wrap_in_file=True` to render a complete, self-contained file (injected no-op target-function stub, declared refs, one reconciled preamble), which is what makes wiring it worthwhile. A new test asserts the full self-contained output, and the CHANGELOG also records the upstream C# array sequence-format change (no spurious `using` lines; typed `new T[] {}` empty form), which flows through the build-time `rest-example` blocks automatically.

All 165 tests pass and the docs build cleanly under `-W` with the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes generated output for `literalizer-call` when `:wrap-in-file:` is set and updates a pinned upstream dependency, which may alter rendered docs/code snippets across projects using this extension.
> 
> **Overview**
> Bumps the pinned `literalizer` dependency to `2026.5.17.1` (including lockfile updates) and documents the resulting output changes in `CHANGELOG.rst`.
> 
> Updates `literalizer-call` to actually pass `wrap_in_file` through to `literalize_call`, so `:wrap-in-file:` now emits a self-contained file (e.g., injected stub + reconciled preamble) instead of being silently ignored; adds a regression test covering the new wrapped output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a711ac3aa6031e750b174ff3b26364762c2e9e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->