### PR TITLE
Bump literalizer to 2026.5.18 and allow empty :parameter-names: (#226)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,24 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.5.18``.
+- ``:parameter-names:`` is now optional on the ``literalizer-call``
+  directive.
+  An empty (or omitted) value means the call takes *no* arguments,
+  rather than the previous behavior where an empty value parsed as a
+  single empty-named argument.
+  Combined with ``:per-element:`` over a single-element source and
+  ``:variable-name:``, this renders a no-argument constructor bound to
+  a variable (``p1 = Playlist()`` / ``let p1 = Playlist();`` /
+  ``auto p1 = Playlist();``), the construction line that
+  ``literalizer-call`` could not previously express -- the original
+  motivation of the ``:variable-name:`` feature.
+- ``:variable-name:`` combined with ``:per-element:`` no longer always
+  fails: following upstream ``literalizer`` ``2026.5.18`` it binds the
+  call to the variable when the source produces exactly one call (a
+  single-element list), and still surfaces a clean ``ExtensionError``
+  when the source produces zero or more than one call.
+
 2026.05.17.1
 ------------
 

--- a/docs/source/_examples/no_args.yaml
+++ b/docs/source/_examples/no_args.yaml
@@ -1,0 +1,3 @@
+---
+# A single row with no values: one call that takes no arguments.
+- []

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -591,6 +591,24 @@ renders as:
       :parameter-names: flag,count
       :per-element:
 
+A no-argument constructor bound to a variable is expressed with an
+empty ``:parameter-names:``, ``:per-element:``, and a single-element
+source.  Given :file:`_examples/no_args.yaml` containing:
+
+.. literalinclude:: _examples/no_args.yaml
+   :language: yaml
+
+the directive renders the language-idiomatic no-argument construction:
+
+.. rest-example::
+
+   .. literalizer-call:: _examples/no_args.yaml
+      :language: rust
+      :target-function: Playlist
+      :parameter-names:
+      :per-element:
+      :variable-name: p1
+
 ``literalizer-call`` directive options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -598,11 +616,15 @@ renders as:
    The function expression to call (e.g. ``my_func`` or
    ``throttler.should_send_notification``).
 
-``:parameter-names:`` (required)
+``:parameter-names:`` (optional)
    Comma-separated parameter names, positionally mapped to each
    element in each row.  For positional-call languages (like Go) these
    are unused in the output but still determine how many values to
    expect per row.
+   An empty (or omitted) value means the call takes *no* arguments,
+   which -- combined with ``:per-element:`` over a single-element
+   source and ``:variable-name:`` -- renders a no-argument constructor
+   bound to a variable (see the example below).
 
 ``:per-element:`` (optional flag)
    When set, each top-level list element becomes a separate function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.17.1",
+    "literalizer==2026.5.18",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -1140,12 +1140,19 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
     that call (using the target language's comment syntax), and a blank
     line emits no comment.  The line count must match the number of
     generated calls.
+
+    An empty (or omitted) ``:parameter-names:`` means the call takes *no*
+    arguments.  Combined with ``:per-element:`` over a single-element
+    source (e.g. ``- []``) and ``:variable-name:``, this renders a
+    no-argument constructor bound to a variable -- ``p1 = Playlist()`` /
+    ``let p1 = Playlist::new();`` / ``auto p1 = Playlist();`` -- in the
+    target language's idiom.
     """
 
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
         **_COMMON_OPTIONS,
         "target-function": directives.unchanged_required,
-        "parameter-names": directives.unchanged_required,
+        "parameter-names": directives.unchanged,
         "per-element": directives.flag,
         "call-transform": directives.unchanged_required,
         "zip-file": directives.unchanged_required,
@@ -1234,7 +1241,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         return _LiteralizerCallOptions(
             **_common_option_args(options=self.options),
             target_function=self.options["target-function"],
-            parameter_names=self.options["parameter-names"],
+            parameter_names=self.options.get("parameter-names", ""),
             per_element="per-element" in self.options,
             call_transform=self.options.get("call-transform"),
             zip_file=self.options.get("zip-file"),
@@ -1259,9 +1266,18 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         include_preamble = options.include_preamble
         omit_code = options.omit_code
         target_function = options.target_function
-        parameter_names = [
-            p.strip() for p in options.parameter_names.split(sep=",")
-        ]
+        # An empty (or omitted) ``:parameter-names:`` means *no*
+        # arguments rather than one empty-named argument: splitting ``""``
+        # on ``,`` would yield ``['']`` (a single argument), so the
+        # zero-argument call -- e.g. a no-argument constructor bound to
+        # ``:variable-name:`` -- would be unreachable.  An empty value
+        # therefore parses to ``[]``.
+        if options.parameter_names.strip():
+            parameter_names = [
+                p.strip() for p in options.parameter_names.split(sep=",")
+            ]
+        else:
+            parameter_names = []
         per_element = options.per_element
         wrap_in_file = options.wrap_in_file
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5673,13 +5673,13 @@ def test_literalizer_call_existing_variable_rust(
     app.cleanup()
 
 
-def test_literalizer_call_variable_form_per_element_error(
+def test_literalizer_call_variable_form_per_element_single_element(
     *,
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
 ) -> None:
-    """``:variable-name:`` with ``:per-element:`` surfaces literalizer's
-    ``UnsupportedCallShapeError`` as an ``ExtensionError``.
+    """``:variable-name:`` with ``:per-element:`` over a single-element
+    source binds the one resulting call to the variable.
     """
     source_directory = tmp_path / "source"
     source_directory.mkdir()
@@ -5707,8 +5707,150 @@ def test_literalizer_call_variable_form_per_element_error(
         srcdir=source_directory,
         confoverrides={"extensions": ["sphinx_literalizer"]},
     )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    expected = 'let my_data = make_widget(HashMap::from([("count", 42)]));'
+    assert text == expected
+    app.cleanup()
+
+
+def test_literalizer_call_variable_form_per_element_multi_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:variable-name:`` with ``:per-element:`` over a source that
+    produces more than one call surfaces literalizer's
+    ``UnsupportedCallShapeError`` as an ``ExtensionError``.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=[{"count": 1}, {"count": 2}]),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: rust
+           :target-function: make_widget
+           :parameter-names: count
+           :per-element:
+           :variable-name: my_data
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
     with pytest.raises(expected_exception=ExtensionError):
         app.build()
+    app.cleanup()
+
+
+@pytest.mark.parametrize(
+    argnames=("language", "expected"),
+    argvalues=[
+        ("python", "p1 = Playlist()"),
+        ("rust", "let p1 = Playlist();"),
+        ("cpp", "auto p1 = Playlist();"),
+        ("go", "p1 := Playlist()"),
+        ("ruby", "p1 = Playlist()"),
+    ],
+)
+def test_literalizer_call_zero_arg_constructor_variable_name(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+    language: str,
+    expected: str,
+) -> None:
+    """An empty ``:parameter-names:`` with ``:per-element:`` over a
+    single-element source binds a no-argument constructor to the
+    variable.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(data="- []\n")
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text=f"""\
+        Test
+        ====
+
+        .. literalizer-call:: data.yaml
+           :language: {language}
+           :target-function: Playlist
+           :parameter-names:
+           :per-element:
+           :variable-name: p1
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert text == expected
+    app.cleanup()
+
+
+def test_literalizer_call_parameter_names_omitted(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Omitting ``:parameter-names:`` entirely is equivalent to an empty
+    value: the call takes no arguments.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[[]]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: Playlist
+           :per-element:
+           :variable-name: p1
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert text == "p1 = Playlist()"
     app.cleanup()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.17.1"
+version = "2026.5.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -770,9 +770,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/25/106fc073ed2920cee751e66f4325da6dfa6b2464f9cc78decbc935d62135/literalizer-2026.5.17.1.tar.gz", hash = "sha256:22025b03be1e7bd4aa4e6b2b9271cc3cd7137cf97c99a655cf184e073e289aaf", size = 2830505, upload-time = "2026-05-17T16:17:17.101Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/17/0643744e2b2597bbd6ba72003549f707ba16c399d492cf291a046a8110c3/literalizer-2026.5.18.tar.gz", hash = "sha256:4c82aa48953d68940d2811f4da2ec906dbc298979325ae969963f20e235e7024", size = 2862582, upload-time = "2026-05-18T07:26:07.001Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fb/6c9d60c36cb425a665235c61db9972c8336ddaaa6785ce4c341280f8fa19/literalizer-2026.5.17.1-py3-none-any.whl", hash = "sha256:98fe89107868a7d27462fdb0315ca646e993758842ec7bf69c9ede1655165ed8", size = 679691, upload-time = "2026-05-17T16:17:15.486Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/68/38539bd8c2eaeb78cc0bd0d6ef60ad34eb2676303b881e1b05716f42c49b/literalizer-2026.5.18-py3-none-any.whl", hash = "sha256:04a834fffb570b40d2616556283349b0adb5085ec8a186de1af1cd7ddb58dc3c", size = 688123, upload-time = "2026-05-18T07:26:04.898Z" },
 ]
 
 [[package]]
@@ -2067,7 +2067,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.17.1" },
+    { name = "literalizer", specifier = "==2026.5.18" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.0" },


### PR DESCRIPTION
Fixes #226. Bumps `literalizer` to `2026.5.18`, which binds a `variable_form` whenever the input produces exactly one call, making the previously-unrepresentable zero-argument constructor case reachable via `:per-element:` over a single-element source. `:parameter-names:` is now optional on `literalizer-call`: an empty or omitted value means the call takes *no* arguments (it was previously parsed as one empty-named argument), so a no-argument constructor can be bound to `:variable-name:` (`p1 = Playlist()` / `let p1 = Playlist();` / `auto p1 = Playlist();`). The `:variable-name:` + `:per-element:` combination now succeeds for a single-call source and still raises a clean `ExtensionError` for zero or many calls. Adds docs (a worked `rest-example`), a CHANGELOG entry, and tests covering the zero-argument binding across Python/Rust/C++/Go/Ruby plus single- and multi-element behavior; the full test suite, ruff/mypy/pyright/interrogate/doc8/check-manifest, and the `-W` docs build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes directive option parsing/validation and bumps the upstream `literalizer` dependency, which can affect rendered documentation output and build behavior for existing projects relying on the prior empty-parameter parsing.
> 
> **Overview**
> Bumps the pinned `literalizer` dependency to `2026.5.18`.
> 
> Updates `literalizer-call` so `:parameter-names:` is **optional**, and an empty/omitted value now means **zero arguments** (parsed as `[]` instead of a single empty name), enabling no-arg calls/constructors to be rendered and bound via `:variable-name:` with `:per-element:` when the source produces exactly one call.
> 
> Adds documentation and examples for the no-argument constructor pattern, and expands tests to cover single-element success, multi-element error behavior, empty vs omitted `:parameter-names:`, and expected output across multiple languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a2ade4321076983972735a4c1945954819258b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->