### PR TITLE
Bump literalizer to 2026.5.18.1 and accept :modifiers: mut for Rust

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Next
 ----
 
+- Bumped ``literalizer`` to ``2026.5.18.1``.
+- ``:modifiers: mut`` is now accepted for Rust.
+  Following upstream ``literalizer`` ``2026.5.18.1``, which adds a
+  ``MUT`` member to ``Rust.Modifiers``, combining ``:variable-name:``
+  with ``:modifiers: mut`` renders a mutable Rust binding
+  (``let mut p1 = Playlist::new();``) instead of the immutable default
+  (``let p1 = Playlist::new();``).
+  This unblocks migrating a construct-then-mutate ladder to Rust, where
+  the constructed value is bound and then mutated through the binding.
+
 2026.05.18
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -287,6 +287,9 @@ Directive options
       ``readonly``.
    ``Java``
       ``public``, ``private``, ``protected``, ``static``, ``final``.
+   ``Rust``
+      ``mut`` (a mutable ``let mut`` binding, so the bound value can be
+      mutated through the binding).
 
 ``:variable-type-hints:`` (optional)
    Whether to add type hints to variable declarations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.18",
+    "literalizer==2026.5.18.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5813,6 +5813,50 @@ def test_literalizer_call_zero_arg_constructor_variable_name(
     app.cleanup()
 
 
+def test_literalizer_call_rust_mut_variable_name(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:modifiers: mut`` with ``:variable-name:`` renders a mutable
+    Rust binding, so the constructed value can be mutated through the
+    binding (the construct-then-mutate ladder of issue #228).
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(data="- []\n")
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.yaml
+           :language: rust
+           :target-function: Playlist
+           :parameter-names:
+           :per-element:
+           :variable-name: p1
+           :modifiers: mut
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert text == "let mut p1 = Playlist();"
+    app.cleanup()
+
+
 def test_literalizer_call_parameter_names_omitted(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.18"
+version = "2026.5.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -770,9 +770,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/17/0643744e2b2597bbd6ba72003549f707ba16c399d492cf291a046a8110c3/literalizer-2026.5.18.tar.gz", hash = "sha256:4c82aa48953d68940d2811f4da2ec906dbc298979325ae969963f20e235e7024", size = 2862582, upload-time = "2026-05-18T07:26:07.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ab/33d65c75c6815cde734c0dc000031c7c544119494a4377c3707f8f68ccb2/literalizer-2026.5.18.1.tar.gz", hash = "sha256:0f1400dee866c6e0e6f5a8363641e9aa4d5518dedfd5b281d9d09a67eebd0b40", size = 2880647, upload-time = "2026-05-18T10:51:07.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/68/38539bd8c2eaeb78cc0bd0d6ef60ad34eb2676303b881e1b05716f42c49b/literalizer-2026.5.18-py3-none-any.whl", hash = "sha256:04a834fffb570b40d2616556283349b0adb5085ec8a186de1af1cd7ddb58dc3c", size = 688123, upload-time = "2026-05-18T07:26:04.898Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d2/c9631c225bf936a7a7ad84086d52dbc14a15b4bc9e0b5290d613829f1b58/literalizer-2026.5.18.1-py3-none-any.whl", hash = "sha256:c42a2b8d6251756183574d1ffc8886d4ee4d09464412a5bc9e5bba83df7d9f95", size = 690351, upload-time = "2026-05-18T10:51:05.095Z" },
 ]
 
 [[package]]
@@ -2067,7 +2067,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.18" },
+    { name = "literalizer", specifier = "==2026.5.18.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.0" },


### PR DESCRIPTION
Bumps `literalizer` to `2026.5.18.1`, whose new `Rust.Modifiers.MUT` member makes `:variable-name:` + `:modifiers: mut` render a mutable Rust binding (`let mut p1 = Playlist();`) instead of the immutable default, unblocking construct-then-mutate ladder migrations to Rust (issue #228). `:modifiers:` was already fully wired, so no extension source change was needed. Adds `tests/test_extension.py::test_literalizer_call_rust_mut_variable_name`, a CHANGELOG entry, and documents Rust `mut` in the `:modifiers:` supported-values list. Verified against the real released package: full suite green (173 passed) and docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins `literalizer` to `2026.5.18.1`, which can subtly change generated code output across languages; risk is mitigated by a targeted new Rust regression test and doc updates.
> 
> **Overview**
> Bumps the pinned `literalizer` dependency (and `uv.lock`) to `2026.5.18.1` to pick up upstream Rust support for `:modifiers: mut` when combined with `:variable-name:`.
> 
> Adds documentation and changelog entries for Rust `mut`, and introduces a new test asserting `literalizer-call` renders `let mut <name> = ...;` for Rust variable bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93f93dc34205cfe694a7cb8eb8b387e414c5c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->