### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ ci:
     - shfmt-docs
     - spelling
     - sphinx-lint
+    - strict-kwargs-fix
     - ty
     - ty-docs
     - vulture
@@ -299,6 +300,16 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies: [*uv_version]
+        stages: [pre-commit]
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -301,7 +301,6 @@ repos:
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
+
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ optional-dependencies.dev = [
     "sphinx-substitution-extensions==2026.1.12",
     "sphinx-toolbox==4.2.0rc1",
     "sphinxcontrib-spelling==8.0.2",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ optional-dependencies.dev = [
     "sphinx-substitution-extensions==2026.1.12",
     "sphinx-toolbox==4.2.0rc1",
     "sphinxcontrib-spelling==8.0.2",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
     "literalizer==2026.5.18.1",
     "sphinx>=7.0",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ dependencies = [
     "literalizer==2026.5.18.1",
     "sphinx>=7.0",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
-
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",

--- a/uv.lock
+++ b/uv.lock
@@ -2092,7 +2092,7 @@ requires-dist = [
     { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "sphinx-toolbox", marker = "extra == 'dev'", specifier = "==4.2.0rc1" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },
-    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18" },
+    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18.post1" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.36" },
     { name = "types-docutils", marker = "extra == 'dev'", specifier = "==0.22.3.20260508" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
@@ -2282,15 +2282,15 @@ wheels = [
 
 [[package]]
 name = "strict-kwargs"
-version = "2026.5.18"
+version = "2026.5.18.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ty" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/5f/214c7046d4fdb7562db842baeeb8b3dda4521c2736f4ac5fb10ab3397f0c/strict_kwargs-2026.5.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e60f890d25dde613b337eef035b96ed820acafdca46ec3349b35f4d5af55c5ac", size = 2088143, upload-time = "2026-05-18T10:43:13.197Z" },
-    { url = "https://files.pythonhosted.org/packages/79/0d/989af3f5eda8cd14bd80488e449f8f40d81709de44dd376f309df83bb726/strict_kwargs-2026.5.18-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:2ce07d85420eed40e51b0a61681db39fd56ed2be97f73780ef2be97ef9373c1b", size = 2187277, upload-time = "2026-05-18T10:43:14.783Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ea/8c711d39423fa503f94a4afd5913e3d5ae2f87d1e9009d2219e47c78c473/strict_kwargs-2026.5.18-py3-none-win_amd64.whl", hash = "sha256:c90ae750b5754176e943bebaee42d34e51433ead05da60908159b42059ccea75", size = 1983606, upload-time = "2026-05-18T10:43:16.493Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1b/748e7c411a22c26bd8488d4f7b25aaf72c72c2ed68a4e61f0fe802d02136/strict_kwargs-2026.5.18.post1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72241056a9bf0bfb9c522c5e888ef9868556fa2475890b90f29ae78b837eefb9", size = 2184045, upload-time = "2026-05-18T14:42:59.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/76/a3a6fa1082e30fdd8dee750bac496e1595d963e1155572e4ffb3f1cb3761/strict_kwargs-2026.5.18.post1-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:7dea7f9ba8557f57fbf56309735780c1d0b83627f237aeb77f1ee50b7020ac4c", size = 2294579, upload-time = "2026-05-18T14:43:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/62/75/15f0de12cf822ff2d1a098fdbe70d57c9d262868dfd728d5ea9cb3104234/strict_kwargs-2026.5.18.post1-py3-none-win_amd64.whl", hash = "sha256:eaad5813f39f338eaa3674aec6bf1463fc3ab2ce47f188262592486645d77132", size = 2069130, upload-time = "2026-05-18T14:43:03.323Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2045,6 +2045,7 @@ dev = [
     { name = "sphinx-substitution-extensions" },
     { name = "sphinx-toolbox" },
     { name = "sphinxcontrib-spelling" },
+    { name = "strict-kwargs" },
     { name = "ty" },
     { name = "types-docutils" },
     { name = "vulture" },
@@ -2091,6 +2092,7 @@ requires-dist = [
     { name = "sphinx-substitution-extensions", marker = "extra == 'dev'", specifier = "==2026.1.12" },
     { name = "sphinx-toolbox", marker = "extra == 'dev'", specifier = "==4.2.0rc1" },
     { name = "sphinxcontrib-spelling", marker = "extra == 'dev'", specifier = "==8.0.2" },
+    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.36" },
     { name = "types-docutils", marker = "extra == 'dev'", specifier = "==0.22.3.20260508" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
@@ -2276,6 +2278,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "strict-kwargs"
+version = "2026.5.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ty" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/5f/214c7046d4fdb7562db842baeeb8b3dda4521c2736f4ac5fb10ab3397f0c/strict_kwargs-2026.5.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e60f890d25dde613b337eef035b96ed820acafdca46ec3349b35f4d5af55c5ac", size = 2088143, upload-time = "2026-05-18T10:43:13.197Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0d/989af3f5eda8cd14bd80488e449f8f40d81709de44dd376f309df83bb726/strict_kwargs-2026.5.18-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:2ce07d85420eed40e51b0a61681db39fd56ed2be97f73780ef2be97ef9373c1b", size = 2187277, upload-time = "2026-05-18T10:43:14.783Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ea/8c711d39423fa503f94a4afd5913e3d5ae2f87d1e9009d2219e47c78c473/strict_kwargs-2026.5.18-py3-none-win_amd64.whl", hash = "sha256:c90ae750b5754176e943bebaee42d34e51433ead05da60908159b42059ccea75", size = 1983606, upload-time = "2026-05-18T10:43:16.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling (pre-commit config and dev dependencies) and do not affect runtime/library behavior, though they may rewrite call sites during commits.
> 
> **Overview**
> Adds a new `strict-kwargs` pre-commit hook (`strict-kwargs-fix`) that runs in *fix* mode (serially) to rewrite positional arguments into keyword arguments on commit.
> 
> Wires `strict-kwargs==2026.5.18.post1` into the dev dependency set and `uv.lock`, and marks the hook as skipped in pre-commit CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a161abcaf67b78586deb96305779166340a42b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->