### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",
+    "towncrier==25.8.0",
 ]
 urls.Documentation = "https://adamtheturtle.github.io/sphinx-literalizer/"
 urls.Source = "https://github.com/adamtheturtle/sphinx-literalizer"

--- a/uv.lock
+++ b/uv.lock
@@ -2096,6 +2096,7 @@ dev = [
 ]
 release = [
     { name = "check-wheel-contents" },
+    { name = "towncrier" },
 ]
 
 [package.metadata]
@@ -2139,6 +2140,7 @@ requires-dist = [
     { name = "sphinxcontrib-towncrier", marker = "extra == 'dev'", specifier = "==0.5.0a0" },
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.19.post3" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
+    { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.38" },
     { name = "types-docutils", marker = "extra == 'dev'", specifier = "==0.22.3.20260518" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change only; primary risk is minor release workflow impact if extra resolution differs in CI.
> 
> **Overview**
> Adds `towncrier==25.8.0` to the `release` optional dependency extra so release jobs that install only `--extra=release` can run `towncrier build`.
> 
> Updates `uv.lock` to reflect the new `release` extra entry and the corresponding `requires-dist` marker for `towncrier`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d152bde4e87a73bbcad2bf948ca52d09357da7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->