### PR TITLE
Align Pylint config with literalizer

### DIFF
--- a/newsfragments/241.change.rst
+++ b/newsfragments/241.change.rst
@@ -1,0 +1,1 @@
+Aligned the Pylint configuration more closely with ``literalizer``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,9 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -17,6 +17,7 @@ Odin
 PascalCase
 PureScript
 Pygments
+Pylint
 Pytest
 Raku
 Roc
@@ -42,6 +43,7 @@ datetimes
 dicts
 doctree
 enum
+fallbacks
 fortran
 frozenset
 getter
@@ -50,6 +52,7 @@ iso
 json
 julia
 kwarg
+literalized
 literalizer
 literalizer's
 mojo


### PR DESCRIPTION
## Summary
- Add Pylint fail-on for useless-suppression to match literalizer.
- Add a towncrier fragment for issue 241.

Closes #241.

## Validation
- uv run --extra=dev -m pytest
- uv run --extra=dev prek run pylint --all-files --hook-stage manual
- uv run --extra=dev prek run pylint-docs --all-files --hook-stage manual

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-only changes that tighten lint enforcement (failing builds on `useless-suppression`) plus a small changelog fragment and spelling dictionary updates.
> 
> **Overview**
> Aligns the Pylint configuration with `literalizer` by adding `MAIN.fail-on = ["useless-suppression"]`, causing CI/lint runs to error when a suppression pragma is unnecessary.
> 
> Adds a Towncrier news fragment for this change and updates the spelling private dictionary with a few new accepted words (e.g. `Pylint`, `fallbacks`, `literalized`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e49ff0227009a908f812ca680e3a719a2d312566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->