### PR TITLE
Add constructor-class support to literalizer-call

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -595,8 +595,9 @@ renders as:
       :per-element:
 
 A no-argument constructor bound to a variable is expressed with an
-empty ``:parameter-names:``, ``:per-element:``, and a single-element
-source.  Given :file:`_examples/no_args.yaml` containing:
+empty ``:parameter-names:`` (or omitted ``:parameter-names:``),
+``:per-element:``, and a single-element source.  Given
+:file:`_examples/no_args.yaml` containing:
 
 .. literalinclude:: _examples/no_args.yaml
    :language: yaml
@@ -607,17 +608,23 @@ the directive renders the language-idiomatic no-argument construction:
 
    .. literalizer-call:: _examples/no_args.yaml
       :language: rust
-      :target-function: Playlist
-      :parameter-names:
+      :constructor-class: Playlist
       :per-element:
       :variable-name: p1
 
 ``literalizer-call`` directive options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``:target-function:`` (required)
+``:target-function:`` (required unless ``:constructor-class:`` is set)
    The function expression to call (e.g. ``my_func`` or
    ``throttler.should_send_notification``).
+
+``:constructor-class:`` (required unless ``:target-function:`` is set)
+   A class/type name whose no-argument constructor should be called using
+   the selected language's idiom.  For example, ``Playlist`` renders as
+   ``Playlist()``, ``new Playlist()``, ``NewPlaylist()``,
+   ``Playlist.new()``, or ``Playlist::new()`` depending on the language.
+   This option cannot be combined with ``:target-function:``.
 
 ``:parameter-names:`` (optional)
    Comma-separated parameter names, positionally mapped to each

--- a/newsfragments/252.change.rst
+++ b/newsfragments/252.change.rst
@@ -1,0 +1,1 @@
+Add ``:constructor-class:`` to ``literalizer-call`` for language-specific constructor targets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.5.21",
+    "literalizer==2026.5.21.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -61,6 +61,7 @@ norg
 overridable
 php
 positionally
+pragma
 pre
 prepends
 rawsource

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -1136,7 +1136,6 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :constructor-class: Widget
            :per-element:
            :variable-name: widget
-           :modifiers: mut
 
     ``:call-transform:`` substitutes these placeholders in the template:
     ``$call`` (and the ``$0`` alias) for the rendered call expression,
@@ -1293,11 +1292,10 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             return target_function
 
         constructor_class = options.constructor_class
-        if constructor_class is not None:
-            return language_spec.format_constructor_target(constructor_class)
-
-        msg = "target source options are validated during parsing"
-        raise AssertionError(msg)
+        if constructor_class is None:  # pragma: no cover
+            msg = "target source options are validated during parsing"
+            raise AssertionError(msg)
+        return language_spec.format_constructor_target(constructor_class)
 
     def run(self) -> list[nodes.Node]:
         """Read the data file and produce function call expressions."""

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -468,7 +468,8 @@ class _LiteralizerOptions(_CommonOptions):
 class _LiteralizerCallOptions(_CommonOptions):
     """Typed options for the ``literalizer-call`` directive."""
 
-    target_function: str
+    target_function: str | None
+    constructor_class: str | None
     parameter_names: str
     per_element: bool
     call_transform: str | None
@@ -1130,11 +1131,23 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
            :existing-variable:
            :modifiers: public,static
 
+        .. literalizer-call:: path/to/no_args.yaml
+           :language: rust
+           :constructor-class: Widget
+           :per-element:
+           :variable-name: widget
+           :modifiers: mut
+
     ``:call-transform:`` substitutes these placeholders in the template:
     ``$call`` (and the ``$0`` alias) for the rendered call expression,
     ``$index`` for the zero-based call position, and ``$zipped`` for the
     matching ``:zip-file:`` element rendered as a native literal (empty
     when no ``:zip-file:`` is given).
+
+    Use exactly one of ``:target-function:`` and
+    ``:constructor-class:``.  ``:constructor-class:`` formats a
+    language-specific zero-argument constructor target and then renders
+    through the same call machinery as ``:target-function:``.
 
     ``:comment-file:`` is a text file with one line per generated call;
     each non-blank line is emitted as a trailing source comment after
@@ -1153,6 +1166,7 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
     option_spec: ClassVar[dict[str, Callable[[str], Any]] | None] = {
         **_COMMON_OPTIONS,
         "target-function": directives.unchanged_required,
+        "constructor-class": directives.unchanged_required,
         "parameter-names": directives.unchanged,
         "per-element": directives.flag,
         "call-transform": directives.unchanged_required,
@@ -1239,9 +1253,24 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
     def _parse_options(self) -> _LiteralizerCallOptions:
         """Parse ``self.options`` into the typed options dataclass."""
+        target_function = self.options.get("target-function")
+        constructor_class = self.options.get("constructor-class")
+        if target_function is None and constructor_class is None:
+            msg = (
+                "Use exactly one of ':target-function:' and "
+                "':constructor-class:'."
+            )
+            raise ExtensionError(message=msg)
+        if target_function is not None and constructor_class is not None:
+            msg = (
+                "':target-function:' cannot be combined with "
+                "':constructor-class:'."
+            )
+            raise ExtensionError(message=msg)
         return _LiteralizerCallOptions(
             **_common_option_args(options=self.options),
-            target_function=self.options["target-function"],
+            target_function=target_function,
+            constructor_class=constructor_class,
             parameter_names=self.options.get("parameter-names", ""),
             per_element="per-element" in self.options,
             call_transform=self.options.get("call-transform"),
@@ -1251,6 +1280,24 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
             consumable_refs=self.options.get("consumable-refs"),
             omit_code="omit-code" in self.options,
         )
+
+    @staticmethod
+    def _resolve_target_function(
+        *,
+        language_spec: Language,
+        options: _LiteralizerCallOptions,
+    ) -> str:
+        """Resolve the explicit or constructor-derived call target."""
+        target_function = options.target_function
+        if target_function is not None:
+            return target_function
+
+        constructor_class = options.constructor_class
+        if constructor_class is not None:
+            return language_spec.format_constructor_target(constructor_class)
+
+        msg = "target source options are validated during parsing"
+        raise AssertionError(msg)
 
     def run(self) -> list[nodes.Node]:
         """Read the data file and produce function call expressions."""
@@ -1266,7 +1313,6 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
         pre_indent_level = options.pre_indent_level
         include_preamble = options.include_preamble
         omit_code = options.omit_code
-        target_function = options.target_function
         # An empty (or omitted) ``:parameter-names:`` means *no*
         # arguments rather than one empty-named argument: splitting ``""``
         # on ``,`` would yield ``['']`` (a single argument), so the
@@ -1316,6 +1362,10 @@ class LiteralizerCallDirective(_BaseLiteralizerDirective):
 
         def _do(language_spec: Language) -> LiteralizeResult:
             """Render the calls for *source* with the built language."""
+            target_function = self._resolve_target_function(
+                language_spec=language_spec,
+                options=options,
+            )
             return literalize_call(
                 source=source,
                 input_format=input_format,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5813,6 +5813,139 @@ def test_literalizer_call_zero_arg_constructor_variable_name(
     app.cleanup()
 
 
+@pytest.mark.parametrize(
+    argnames=("language", "expected"),
+    argvalues=[
+        ("python", "p1 = Playlist()"),
+        ("rust", "let p1 = Playlist::new();"),
+        ("cpp", "auto p1 = Playlist();"),
+        ("go", "p1 := NewPlaylist()"),
+        ("ruby", "p1 = Playlist.new()"),
+    ],
+)
+def test_literalizer_call_constructor_class_variable_name(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+    language: str,
+    expected: str,
+) -> None:
+    """``:constructor-class:`` derives the call target from the
+    selected language.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(data="- []\n")
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text=f"""\
+        Test
+        ====
+
+        .. literalizer-call:: data.yaml
+           :language: {language}
+           :constructor-class: Playlist
+           :per-element:
+           :variable-name: p1
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    text = literal_block.astext()
+    assert text == expected
+    app.cleanup()
+
+
+def test_literalizer_call_requires_target_or_constructor(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``literalizer-call`` requires an explicit target source."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[[]]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"^Use exactly one of ':target-function:' and "
+            r"':constructor-class:'\.$"
+        ),
+    ):
+        app.build()
+    app.cleanup()
+
+
+def test_literalizer_call_target_function_and_constructor_class_rejected(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:constructor-class:`` cannot be combined with an explicit
+    target function.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[[]]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.json
+           :language: python
+           :target-function: Playlist
+           :constructor-class: Playlist
+           :per-element:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"^':target-function:' cannot be combined with "
+            r"':constructor-class:'\.$"
+        ),
+    ):
+        app.build()
+    app.cleanup()
+
+
 def test_literalizer_call_rust_mut_variable_name(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.5.21"
+version = "2026.5.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -779,9 +779,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/63/f421cd89a34aadbd37ef899c45c188db6bf4e30d5dc9cb9b7d6d69279e73/literalizer-2026.5.21.tar.gz", hash = "sha256:14e2756ae4aa461f36b4e19006791c8e424cf58067c828ac2ec4f0f4d4c864ae", size = 2878832, upload-time = "2026-05-21T13:06:38.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/ce/3ed88c22b19e83e96298e0e7f436af7118522d0c58e77a9cbe049fd2ad7b/literalizer-2026.5.21.1.tar.gz", hash = "sha256:96b04a90d3a17e5c5c6ecca419e5c5c901377539f3a947eac9841666175218ec", size = 2916432, upload-time = "2026-05-21T14:35:04.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/14/70ac570ee17a918e7477e6dbfcd04907ac2685c9b1d1e210eee8a2394c0c/literalizer-2026.5.21-py3-none-any.whl", hash = "sha256:db0bf099cf4639949a9009630c3ed0fdab0d3c01f6e803ed164b1159e387ec6e", size = 690755, upload-time = "2026-05-21T13:06:36.105Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/ee2306d0b1b857f6c54f0cca67bf7597c9ad62b9f6a411ed20e66fa00c5a/literalizer-2026.5.21.1-py3-none-any.whl", hash = "sha256:23a3ea91bcd13b6129a088476108c07176ab4dc493858e3d8bad632d869f14f8", size = 692980, upload-time = "2026-05-21T14:35:01.572Z" },
 ]
 
 [[package]]
@@ -2111,7 +2111,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.5.21" },
+    { name = "literalizer", specifier = "==2026.5.21.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.20.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.1" },


### PR DESCRIPTION
## Summary
Adds `:constructor-class:` to `literalizer-call` and routes it through literalizer's language-specific constructor target formatter.
Bumps literalizer to `2026.5.21.1`, updates docs, tests Python/Rust/C++/Go/Ruby rendering and validation, and adds a Towncrier fragment.
This gives docs authors directive-level constructor sugar instead of maintaining per-language `:target-function:` values.

## Validation
Ran `pytest`, `ruff`, `mypy`, `doc8`, `sphinx-build`, `uv lock --check`, and the commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized to `literalizer-call` option parsing/target resolution plus docs/tests and a patch-level dependency bump, with explicit validation for misconfiguration.
> 
> **Overview**
> Adds a new `:constructor-class:` option to `literalizer-call`, allowing the directive to derive a language-idiomatic zero-argument constructor target (via `Language.format_constructor_target`) instead of requiring per-language `:target-function:` strings.
> 
> Updates directive option validation to require *exactly one* of `:target-function:` or `:constructor-class:`, adds test coverage for multi-language rendering and error cases, refreshes the docs example/option reference, and bumps the `literalizer` dependency to `2026.5.21.1` (plus lockfile/newsfragment updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb5b5acb73735f96481e445439e26c5ebafcdd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->