### PR TITLE
Expose nested RECORD map fallback

### DIFF
--- a/docs/source/_examples/record_nested_maps.json
+++ b/docs/source/_examples/record_nested_maps.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "test_1",
+    "input": {"type": "create", "pr_id": "pr_1", "draft": true},
+    "expected": {"pr_id": "pr_1", "status": "draft"}
+  },
+  {
+    "name": "test_2",
+    "input": {"type": "publish", "pr_id": "pr_1"},
+    "expected": {"error": "invalid_operation"}
+  }
+]

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -143,6 +143,29 @@ With :file:`_examples/record.json`:
       :heterogeneous-strategy: record
       :include-preamble:
 
+Nested map fallback (Rust)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``record`` keeps a uniform outer record even when maps nested under the same
+field have incompatible sibling shapes.  The nested level falls back to the
+language's native map representation and value carrier; no ``:json-type:`` or
+additional directive option is required.  This is useful for test-case data
+such as :file:`_examples/record_nested_maps.json`:
+
+.. literalinclude:: _examples/record_nested_maps.json
+   :language: json
+
+The same ``record`` path is available for C#, C++, Go, Java, Kotlin, Rust, and
+Scala.  For example, Rust remains standard-library-only:
+
+.. rest-example::
+
+   .. literalizer:: _examples/record_nested_maps.json
+      :language: rust
+      :heterogeneous-strategy: record
+      :include-delimiters:
+      :include-preamble:
+
 ``tuple`` (Rust)
 ~~~~~~~~~~~~~~~~
 
@@ -217,7 +240,7 @@ Languages not listed support only ``error`` (set explicitly) and ``auto`` (which
      - Rust
      - A generated tagged ``enum`` plus wrapped values.
    * - ``record``
-     - Go, Java, Kotlin, Rust, Scala
+     - C#, C++, Go, Java, Kotlin, Rust, Scala
      - A generated ``struct`` / record declaration plus a matching literal, for record-shaped mappings.
    * - ``tuple``
      - C++, Rust

--- a/newsfragments/325.change
+++ b/newsfragments/325.change
@@ -1,0 +1,1 @@
+Bumped ``literalizer`` and documented how ``:heterogeneous-strategy: record`` preserves a uniform outer record while falling back to native maps for incompatible nested sibling shapes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.7.14",
+    "literalizer==2026.7.15",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6618,6 +6618,136 @@ def test_heterogeneous_strategy_record_go(
     app.cleanup()
 
 
+@pytest.mark.parametrize(
+    argnames=("language", "record_declaration", "nested_map_literal"),
+    argvalues=[
+        (
+            "csharp",
+            (
+                "record Record0(string Name, Dictionary<string, object> "
+                "Input, Dictionary<string, object> Expected);"
+            ),
+            "new Dictionary<string, object>",
+        ),
+        (
+            "cpp",
+            (
+                "struct Record0 { std::string name; "
+                "std::map<std::string, LiteralizerRecordValue> input; "
+                "std::map<std::string, LiteralizerRecordValue> expected; "
+                "};"
+            ),
+            "std::map<std::string, LiteralizerRecordValue>",
+        ),
+        ("go", "type Record0 struct {", "map[string]any"),
+        (
+            "java",
+            (
+                "record Record0(String name, java.util.Map<String, Object> "
+                "input, java.util.Map<String, Object> expected) {}"
+            ),
+            "Map.ofEntries",
+        ),
+        (
+            "kotlin",
+            (
+                "data class Record0(val name: String, "
+                "val input: Map<String, Any?>, "
+                "val expected: Map<String, Any?>)"
+            ),
+            "mapOf<String, Any?>",
+        ),
+        (
+            "rust",
+            (
+                "struct Record0 {\n"
+                "    name: &'static str,\n"
+                "    input: HashMap<&'static str, Value>,\n"
+                "    expected: HashMap<&'static str, Value>,\n"
+                "}"
+            ),
+            "HashMap::from",
+        ),
+        (
+            "scala",
+            (
+                "case class Record0(name: String, input: Map[String, Any], "
+                "expected: Map[String, Any])"
+            ),
+            "Map[String, Any]",
+        ),
+    ],
+)
+def test_record_nested_map_fallback(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+    language: str,
+    record_declaration: str,
+    nested_map_literal: str,
+) -> None:
+    """Record rendering keeps one outer shape and falls back to maps
+    for incompatible nested sibling shapes in statically typed targets.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(
+            obj=[
+                {
+                    "name": "test_1",
+                    "input": {
+                        "type": "create",
+                        "pr_id": "pr_1",
+                        "draft": True,
+                    },
+                    "expected": {"pr_id": "pr_1", "status": "draft"},
+                },
+                {
+                    "name": "test_2",
+                    "input": {"type": "publish", "pr_id": "pr_1"},
+                    "expected": {"error": "invalid_operation"},
+                },
+            ],
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text=f"""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: {language}
+           :heterogeneous-strategy: record
+           :include-delimiters:
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    output = literal_block.astext()
+    assert record_declaration in output
+    assert output.count("Record0") == 3
+    assert "Record1" not in output
+    assert nested_map_literal in output
+    assert all(
+        value in output
+        for value in ("test_1", "test_2", "draft", "invalid_operation")
+    )
+    app.cleanup()
+
+
 def test_record_struct_name_prefix_python(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.14"
+version = "2026.7.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -784,9 +784,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/de/914bfe3a764aa324ba8891c6d15a33e0308633d712a7242143b4bdf52a11/literalizer-2026.7.14.tar.gz", hash = "sha256:f0f5a688616cec40877830dde339464bd36051597fa14e87acce28a874837655", size = 3360171, upload-time = "2026-07-14T22:07:53.203Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/32/96794276d13893ab58998f416fdf8ffd033b274960f761157542db9d5025/literalizer-2026.7.15.tar.gz", hash = "sha256:88654b090818d99fee74611dd5cd8cb20057432a8eb597ed75e51df969642ff7", size = 3406050, upload-time = "2026-07-15T14:01:42.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/68/4d9fb93c868c8a85ceaf22b2f10cfea69636a8eae1ff0a6f470996ebe77b/literalizer-2026.7.14-py3-none-any.whl", hash = "sha256:9d42ddafa6563b0cae2b4ec917b118a26c09f2dab3424f38be360da6fc3e2e0d", size = 968091, upload-time = "2026-07-14T22:07:50.515Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/59/6e4506d41b683613111fe066179d003ff28fe03f9f0a16e983e0fcc929d8/literalizer-2026.7.15-py3-none-any.whl", hash = "sha256:fe1b23cd03faa18d545a753ce4fb4243ef448b9f7aa8cde3e51bc9fa2c049feb", size = 991375, upload-time = "2026-07-15T14:01:40.088Z" },
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.14" },
+    { name = "literalizer", specifier = "==2026.7.15" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.20.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.9" },


### PR DESCRIPTION
## Summary

- bump `literalizer` from 2026.7.14 to the newly released 2026.7.15
- verify the `record` directive path preserves one uniform outer record while incompatible nested sibling maps fall back to native map/value carriers
- cover C#, C++, Go, Java, Kotlin, Rust, and Scala
- add a documented standard-library-only Rust example and update the RECORD support matrix

## Why

Upstream `literalizer` now handles the nested-map fallback automatically, so no new directive option is needed. This exposes that behavior through `sphinx-literalizer` for the test-case shape described in #325.

## Validation

- `uv run pytest -q --cov-fail-under 100 --cov=src/ --cov=tests .` (190 passed, 100% coverage)
- pre-commit, pre-push, and manual hook stages
- warning-free Sphinx HTML, linkcheck, and spelling builds

Closes #325.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin plus docs and Sphinx extension tests only; no changes to sphinx-literalizer runtime code.
> 
> **Overview**
> Pins **literalizer** to `2026.7.15` (and `uv.lock`) so `:heterogeneous-strategy: record` picks up upstream behavior where the **outer** record stays uniform while **incompatible nested maps** under the same field fall back to native map/value types—no new directive options.
> 
> Docs add `_examples/record_nested_maps.json`, a **Nested map fallback (Rust)** section with a live `literalizer` example, and extend the per-language **`record`** row to **C#** and **C++**. Integration coverage adds `test_record_nested_map_fallback` across C#, C++, Go, Java, Kotlin, Rust, and Scala (single `Record0`, no extra record types). A towncrier fragment records the change for #325.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27b33a058f39a78d994f0d24775af640b515d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->