### PR TITLE
Expose C++ external record names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ env/
 .coverage
 htmlcov/
 .pytest_cache/
+*.profraw
 
 # Ruff
 .ruff_cache/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,10 +23,7 @@ Changelog
 Next
 ----
 
-- Bump ``literalizer`` to ``2026.7.20.1``.  ``literalizer-call`` now
-  correctly produces shared preambles for heterogeneous arguments across
-  ``:per-element:`` calls; the feature is documented with a Rust
-  ``:heterogeneous-strategy: tagged_enum`` example.
+- Bump ``literalizer`` to ``2026.7.21.1``.
 
 2026.07.15
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,12 @@ Next
 
 - Bump ``literalizer`` to ``2026.7.21.1``.
 
+- ``:record-shape-names:`` now exposes literalizer's externally declared
+  C++ record rendering.  With ``:language-version: cpp14`` and
+  ``:heterogeneous-strategy: record``, a shape mapping such as
+  ``title,done=Task`` renders ``std::vector<Task>{...}`` without emitting
+  a duplicate ``struct Task`` declaration.
+
 2026.07.15
 ----------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -129,9 +129,11 @@ Directive options
    of keys to the name used instead of the auto-generated one; for
    example ``x,y=Point; a,b,c=Vec3``.  The name must be a valid
    PascalCase identifier for the selected language and must not collide
-   with the auto-generated names or with another entry.  Available for
-   Go, Java, Kotlin, Rust, and Scala; using it with any other language
-   raises an error.
+   with the auto-generated names or with another entry.  For C++, the
+   name refers to an externally declared struct, so literalizer emits no
+   duplicate declaration; C++14 record lists use an explicit type such
+   as ``std::vector<Task>{...}``.  Available for C++, Go, Java, Kotlin,
+   Rust, and Scala; using it with any other language raises an error.
 
 ``:wrap-in-file:`` (optional flag)
    Wrap the generated code in a complete file/module when the selected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.7.21",
+    "literalizer==2026.7.21.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7229,6 +7229,66 @@ def test_record_shape_names_java(
     app.cleanup()
 
 
+def test_record_shape_names_cpp14_external_record(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """C++14 maps a named record shape to a caller-declared struct."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(
+            obj=[
+                {"title": "Write docs", "done": False},
+                {"title": "Review PR", "done": True},
+            ],
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: cpp
+           :language-version: cpp14
+           :heterogeneous-strategy: record
+           :record-shape-names: title,done=Task
+           :include-delimiters:
+           :include-preamble:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    output = literal_block.astext()
+    assert output == (
+        "#include <initializer_list>\n"
+        "#include <string>\n"
+        "#include <map>\n"
+        "#include <vector>\n"
+        "\n"
+        "std::vector<Task>{\n"
+        '    Task{"Write docs", false},\n'
+        '    Task{"Review PR", true},\n'
+        "}"
+    )
+    assert "struct Task" not in output
+    assert "LiteralizerVariant" not in output
+    app.cleanup()
+
+
 def test_record_shape_names_invalid_name_error(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.21"
+version = "2026.7.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -784,9 +784,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/c4/708636db0d18238f895bec02be32ea74eee211c1e9f48ad7a8dc761e8fb8/literalizer-2026.7.21.tar.gz", hash = "sha256:e1fb985aec83a07cce0215e2efb2a15056484c32aafc889f4758e3bc3185fe20", size = 3586954, upload-time = "2026-07-21T07:14:26.499Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/d8/9dfde0dc8556d18b4658f888b51980b19955f3c5241a3c8b7d8839607a96/literalizer-2026.7.21.1.tar.gz", hash = "sha256:b28ca59128716ad9b3a56849ac7fb67d1e174c3cee4623380783367f178811d7", size = 3611301, upload-time = "2026-07-21T11:23:03.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/54/32fb41f43f5fc86489e48981d33253b0b17bf918a3ee8604f1896f5d1ab2/literalizer-2026.7.21-py3-none-any.whl", hash = "sha256:5803e9b3ac627854ba85f2271e0d2b6a632de9ad89c65b084a6d598f88cc939f", size = 1039713, upload-time = "2026-07-21T07:14:24.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/04e4edb147b177450727197ee31aa47367cce28a55c45271dccdced26d44/literalizer-2026.7.21.1-py3-none-any.whl", hash = "sha256:cf3b6e07fc752c7399cad0863e0efe342d89d72a763f03c007f7f2b194ef0b88", size = 841906, upload-time = "2026-07-21T11:23:00.899Z" },
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.21" },
+    { name = "literalizer", specifier = "==2026.7.21.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.10" },


### PR DESCRIPTION
Expose C++14 externally declared record shapes through `:record-shape-names:` and document the typed `std::vector<Task>{...}` output. Add a regression test ensuring no duplicate struct or Literalizer carrier type is emitted. Also bump literalizer to 2026.7.21.1, refresh the lockfile, and ignore profiling artifacts.\n\nCloses #343.\n\nValidated with `uv run --extra dev pytest` (199 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and documentation/test coverage only; no extension logic changes in this diff.
> 
> **Overview**
> Bumps **literalizer** to `2026.7.21.1` (and `uv.lock`) so `:record-shape-names:` can map heterogeneous record shapes to **caller-declared C++ structs** instead of emitting a generated `struct` or carrier type. With `:language: cpp`, `:language-version: cpp14`, and `:heterogeneous-strategy: record`, a mapping like `title,done=Task` is documented to render as typed `std::vector<Task>{...}`.
> 
> **Docs and changelog** extend `:record-shape-names:` to list **C++** alongside Go, Java, Kotlin, Rust, and Scala, and describe the external-struct semantics. A Sphinx integration test asserts the expected output and that `struct Task` / `LiteralizerVariant` are absent.
> 
> Also ignores `*.profraw` in `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b80025ef631a4100823c0003e70d04e6ffbc01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->