### PR TITLE
Bump literalizer to 2026.7.24.1

### DIFF
--- a/newsfragments/+literalizer-2026.7.24.1.change
+++ b/newsfragments/+literalizer-2026.7.24.1.change
@@ -1,0 +1,4 @@
+C++14 output now preserves externally named records in calls and wraps
+heterogeneous carrier elements explicitly. Carrier strings rendered through
+either directive remain owning ``std::string`` values and can be inspected
+with ``is<std::string>()`` and ``get<std::string>()``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.7.24",
+    "literalizer==2026.7.24.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -6791,7 +6791,7 @@ def test_language_defaults_apply_to_both_directives(
     literal_blocks = list(doctree.findall(condition=nodes.literal_block))
     default_literal, default_call, explicit_override = literal_blocks
     assert 'Task{"Ada", true}' in default_literal.astext()
-    assert "std::map<std::string, Value>" in default_call.astext()
+    assert 'process(Task{"Ada", true});' in default_call.astext()
     assert '.name = "Ada"' in explicit_override.astext()
     app.cleanup()
 
@@ -7491,10 +7491,14 @@ def test_literalizer_call_named_carrier_preamble_only(
         condition=nodes.literal_block,
     )
     assert "struct TaskValue {" in preamble_block.astext()
+    assert (
+        "std::make_shared<TypedHolder<std::string>>" in preamble_block.astext()
+    )
     assert "run(" not in preamble_block.astext()
     assert "struct TaskValue {" not in call_block.astext()
     assert call_block.astext() == (
-        'run("build", std::vector<TaskValue>{1, "fast", nullptr});'
+        'run("build", std::vector<TaskValue>{'
+        'TaskValue{1}, TaskValue{"fast"}, TaskValue{nullptr}});'
     )
     combined = (
         f"{preamble_block.astext()}\n\n"

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.24"
+version = "2026.7.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -784,9 +784,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/8b/55ec67e7f5d1480aa8d1707cbe61f999a77661a15dedc64280454e9e999e/literalizer-2026.7.24.tar.gz", hash = "sha256:4a745ba5a0a8af5268468568d80eed2433d53b1fb861503c33d1f7ebc62872f2", size = 3660357, upload-time = "2026-07-24T08:21:00.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/2a/4474e7f5be258a3d71e203a51f04458b9f6b550044b643d312ba97f33a2e/literalizer-2026.7.24.1.tar.gz", hash = "sha256:2654a5bb96239682d8b907673d862af5da5354deef9e48ae1f7377992a68ee69", size = 3689365, upload-time = "2026-07-24T13:53:50.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/83/d04c046edcf5fd51642ec06ceaa883ecef4f90c4c15c98b2cac21ec7a0ee/literalizer-2026.7.24-py3-none-any.whl", hash = "sha256:86e0b44f1aee67885576a9b8ce5731e296f41d27ee4ec7610239b5abe01159ca", size = 846190, upload-time = "2026-07-24T08:20:58.515Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a2/f5e273dd38ac3fb00daa7a1f48c611dd4e833685604c6691f874364ab10c/literalizer-2026.7.24.1-py3-none-any.whl", hash = "sha256:800aca0c1e686d8f1ec754478051cf9daf7f2bc3359a2aaa3fa120e77ba91a26", size = 848800, upload-time = "2026-07-24T13:53:48.323Z" },
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.24" },
+    { name = "literalizer", specifier = "==2026.7.24.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.10" },


### PR DESCRIPTION
## Summary

Bump literalizer to 2026.7.24.1 and refresh the lockfile after publishing the upstream release.
Update C++14 regression coverage for the release's corrected explicit carrier construction, owning string payloads, and preservation of externally named records in calls.
Add a changelog fragment describing the downstream-visible behavior changes.

## Validation

- `uv run --extra=dev pytest -q` — 215 passed
- `uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose`
- pre-push type-check and manifest hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and expectation-only test updates; no changes to sphinx-literalizer runtime logic.
> 
> **Overview**
> Upgrades **literalizer** to `2026.7.24.1` (including `uv.lock`) and documents the downstream C++14 behavior in a news fragment.
> 
> Regression tests now expect the new literalizer output: **externally named records stay in call sites** (e.g. `process(Task{"Ada", true});` instead of a generic `std::map` type), and **heterogeneous record vectors** render as explicit `TaskValue{…}` elements with preamble support for owning carrier strings (`std::make_shared<TypedHolder<std::string>>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c94af0dc0e08b2072e9ba6f6c1e23bcd4e7f1ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->