### PR TITLE
Cover C++14 external map aliases under ERROR

### DIFF
--- a/newsfragments/358.change
+++ b/newsfragments/358.change
@@ -1,0 +1,3 @@
+C++14 ``:record-shape-names:`` now preserves an externally declared map alias
+as the outer sequence element type with ``:heterogeneous-strategy: error``,
+while retaining native ``std::map`` element expressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.7.24.1",
+    "literalizer @ git+https://github.com/adamtheturtle/literalizer.git@d2d035432359e953d10c9b618215f62c43ba4f09",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7807,6 +7807,61 @@ def test_record_shape_names_cpp14_external_record(
     app.cleanup()
 
 
+def test_record_shape_names_cpp14_error_external_map_alias(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """C++14 ERROR uses a named map shape as the vector element type."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "expenses.json").write_text(
+        data=json.dumps(
+            obj=[
+                {
+                    "expense_id": "001",
+                    "trip_id": "001",
+                    "amount_usd": "49.99",
+                },
+            ],
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: expenses.json
+           :language: cpp
+           :language-version: cpp14
+           :heterogeneous-strategy: error
+           :record-shape-names: expense_id,trip_id,amount_usd=Expense
+           :include-delimiters:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        "std::vector<Expense>{\n"
+        "    std::map<std::string, std::string>{"
+        '{"expense_id", "001"}, {"trip_id", "001"}, '
+        '{"amount_usd", "49.99"}},\n'
+        "}"
+    )
+    app.cleanup()
+
+
 def test_record_shape_names_invalid_name_error(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -773,8 +773,8 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.24.1"
-source = { registry = "https://pypi.org/simple" }
+version = "2026.7.24.1.post7+gd2d035432"
+source = { git = "https://github.com/adamtheturtle/literalizer.git?rev=d2d035432359e953d10c9b618215f62c43ba4f09#d2d035432359e953d10c9b618215f62c43ba4f09" }
 dependencies = [
     { name = "beartype" },
     { name = "pyhumps" },
@@ -783,10 +783,6 @@ dependencies = [
     { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
     { name = "tomlkit" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/2a/4474e7f5be258a3d71e203a51f04458b9f6b550044b643d312ba97f33a2e/literalizer-2026.7.24.1.tar.gz", hash = "sha256:2654a5bb96239682d8b907673d862af5da5354deef9e48ae1f7377992a68ee69", size = 3689365, upload-time = "2026-07-24T13:53:50.369Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/a2/f5e273dd38ac3fb00daa7a1f48c611dd4e833685604c6691f874364ab10c/literalizer-2026.7.24.1-py3-none-any.whl", hash = "sha256:800aca0c1e686d8f1ec754478051cf9daf7f2bc3359a2aaa3fa120e77ba91a26", size = 848800, upload-time = "2026-07-24T13:53:48.323Z" },
 ]
 
 [[package]]
@@ -2115,7 +2111,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.24.1" },
+    { name = "literalizer", git = "https://github.com/adamtheturtle/literalizer.git?rev=d2d035432359e953d10c9b618215f62c43ba4f09" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.10" },


### PR DESCRIPTION
Adds an end-to-end directive regression for C++14 `record-shape-names` with `heterogeneous-strategy: error`, asserting an external `Expense` map alias is retained as the vector element type while elements remain native `std::map` expressions. Pins `literalizer` to the immutable merged upstream fix `d2d03543` and refreshes the lockfile so the tested dependency contains the correction before its next PyPI release. Adds the corresponding Towncrier fragment for #358. The exact CI pytest command passes locally with 216 tests and 100% coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No extension logic changes—only a dependency pin, lockfile refresh, test, and changelog fragment.
> 
> **Overview**
> **Pins `literalizer`** to git commit `d2d03543` (via `pyproject.toml` and `uv.lock`) so C++14 `:record-shape-names:` with `:heterogeneous-strategy: error` keeps an externally declared map alias (e.g. `Expense`) as the outer `std::vector<>` element type while each element still renders as native `std::map` literals.
> 
> Adds an end-to-end Sphinx regression in `tests/test_extension.py` for that output shape and a Towncrier fragment for #358 documenting the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b56b949976e726e158754abb5b213e258ec38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->