### PR TITLE
Support native multiline string formats

### DIFF
--- a/docs/source/_examples/multiline.yaml
+++ b/docs/source/_examples/multiline.yaml
@@ -1,0 +1,4 @@
+---
+message: |-
+  First line
+  Second line

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -480,6 +480,13 @@ Directive options
       ``multiline`` targets ``jdk_16`` even when ``:language-version: jdk_11``
       is also specified.
 
+For example, a small YAML dictionary can keep its message on multiple lines:
+
+.. literalizer:: _examples/multiline.yaml
+   :language: python
+   :include-delimiters:
+   :string-format: multiline
+
 ``:trailing-comma:`` (optional)
    Whether to include a trailing comma after the last element in
    collections.  Supported values:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -468,6 +468,17 @@ Directive options
       Double-quoted strings (default for all languages).
    ``single``
       Single-quoted strings.  Available for JavaScript.
+   ``multiline``
+      Native multiline string syntax.  Available for Python (triple-quoted
+      strings), Java (text blocks), C++ and Rust (collision-free raw string
+      delimiters), C# (verbatim strings), Go (raw string literals), JavaScript
+      (template literals), Kotlin and Scala (triple-quoted strings), and Ruby
+      (multiline single-quoted strings).  Leading and trailing newlines, blank
+      lines, and embedded indentation are preserved.  When a native form
+      cannot safely represent a value, ``literalizer`` uses an escaped string
+      literal instead.  Java text blocks require Java 16, so selecting
+      ``multiline`` targets ``jdk_16`` even when ``:language-version: jdk_11``
+      is also specified.
 
 ``:trailing-comma:`` (optional)
    Whether to include a trailing comma after the last element in

--- a/newsfragments/370.change
+++ b/newsfragments/370.change
@@ -1,0 +1,3 @@
+Expose Literalizer's native ``:string-format: multiline`` option on both
+directives for Python, Java, C++, C#, Go, JavaScript, Kotlin, Ruby, Scala, and
+Rust, including exact whitespace preservation and Java 16 text blocks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.7.29.1",
+    "literalizer==2026.8.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3074,6 +3074,226 @@ def test_string_format_single(
     app.cleanup()
 
 
+def test_string_format_multiline_native_delimiters(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The shared multiline member uses each language's native syntax."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj="first\n\n  indented\nlast"),
+    )
+    languages = (
+        "python",
+        "java",
+        "cpp",
+        "csharp",
+        "go",
+        "javascript",
+        "kotlin",
+        "ruby",
+        "scala",
+        "rust",
+    )
+    directives = "\n\n".join(
+        f".. literalizer:: data.json\n"
+        f"   :language: {language}\n"
+        "   :string-format: multiline"
+        for language in languages
+    )
+    (source_directory / "index.rst").write_text(
+        data=f"Test\n====\n\n{directives}\n",
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    actual = [
+        literal_block.astext()
+        for literal_block in doctree.findall(condition=nodes.literal_block)
+    ]
+    assert actual == [
+        '"""first\n\n  indented\nlast"""',
+        '"""\nfirst\n\n  indented\nlast"""',
+        'R"LITERALIZER(first\n\n  indented\nlast)LITERALIZER"',
+        '@"first\n\n  indented\nlast"',
+        "`first\n\n  indented\nlast`",
+        "`first\n\n  indented\nlast`",
+        '"""first\n\n  indented\nlast"""',
+        "'first\n\n  indented\nlast'",
+        '"""first\n\n  indented\nlast"""',
+        'r#"first\n\n  indented\nlast"#',
+    ]
+    app.cleanup()
+
+
+def test_string_format_multiline_preserves_edge_newlines(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Multiline JSON scalars preserve edge newlines and indentation."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj="\nfirst\n\n  indented\nlast\n"),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :string-format: multiline
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == ('"""\nfirst\n\n  indented\nlast\n"""')
+    app.cleanup()
+
+
+def test_string_format_multiline_literalizer_call_yaml(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Multiline applies to YAML scalars in literalizer-call."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(
+        data="- |+\n  first\n\n    indented\n  last\n",
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer-call:: data.yaml
+           :language: python
+           :target-function: emit
+           :parameter-names: message
+           :per-element:
+           :string-format: multiline
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        'emit(message="""first\n\n  indented\nlast\n""")'
+    )
+    app.cleanup()
+
+
+def test_string_format_multiline_java_promotes_jdk_11(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Java multiline output uses the Java 16 text-block syntax."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj="first\nsecond"),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: java
+           :language-version: jdk_11
+           :string-format: multiline
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == '"""\nfirst\nsecond"""'
+    app.cleanup()
+
+
+def test_unsupported_string_format_multiline_error(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """An unsupported multiline string format raises ExtensionError."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj="first\nsecond"),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: typescript
+           :string-format: multiline
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(
+        expected_exception=ExtensionError,
+        match=(
+            r"Language 'typescript' does not support string-format "
+            r"'multiline'\."
+        ),
+    ):
+        app.build()
+
+
 def test_trailing_comma_no(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.7.29.1"
+version = "2026.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -784,9 +784,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/22/b18e6e83cb01f961e6d06636449fc4719307020d615d02d91009fed558a7/literalizer-2026.7.29.1.tar.gz", hash = "sha256:cbde328bf9cdb60587252fa25977213c01be2a19d5339eb55ab24dd2837c4318", size = 3761548, upload-time = "2026-07-29T16:46:26.034Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/31/66edaa935833129ee7677556f238f7c8664ebe7c7d95cfa26645d8d3771e/literalizer-2026.8.1.tar.gz", hash = "sha256:4aa327de7ca26cadfa28e4810e59e11110a0d7a139a4934a3cbce66e3f563539", size = 3762945, upload-time = "2026-08-01T13:41:44.567Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/75/cbab2ad244a5cafed0f4278f15e20f152b75399b70a5c8179b5d2c9e9461/literalizer-2026.7.29.1-py3-none-any.whl", hash = "sha256:fa7ff45e0c2d934c97587517a20bfd221834fcb19b543ae14903b61588de4e7e", size = 853699, upload-time = "2026-07-29T16:46:23.76Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/53/974b424d575f33fdab9ae1db1da9ef866a496649d126370dea22dc2c6fe8/literalizer-2026.8.1-py3-none-any.whl", hash = "sha256:1f11b5d418d9977002bd55942cabd35b3a270687887586583f4d2ff6b12b7e69", size = 859245, upload-time = "2026-08-01T13:41:42.713Z" },
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.7.29.1" },
+    { name = "literalizer", specifier = "==2026.8.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.11" },


### PR DESCRIPTION
Closes #370.

Bumps Literalizer to 2026.8.1 so both directives expose its native `multiline` string format across all supported languages.

Documents the syntax and Java 16 behavior, adds a changelog fragment, and covers native delimiters, JSON/YAML whitespace preservation, `literalizer-call`, version promotion, and unsupported-language errors.

Validation: 222 tests pass with 100% coverage, the full pre-commit suite passes, and the Sphinx documentation build succeeds with warnings treated as errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump plus docs and integration tests only; no extension logic changes in the diff.
> 
> **Overview**
> **Bumps `literalizer` to 2026.8.1** so `literalizer` and `literalizer-call` can use the new `:string-format: multiline` option (native multiline strings per language, with fallback to escaped literals when needed).
> 
> **Documentation** adds the `multiline` value under `:string-format:`, notes supported languages, whitespace preservation, Java 16 text-block promotion when `jdk_11` is set, and a live example using `docs/source/_examples/multiline.yaml`. A **towncrier** fragment records the user-facing change.
> 
> **Tests** cover per-language native delimiters, edge newlines/indentation, `literalizer-call` with YAML, Java version promotion, and `ExtensionError` when multiline is used with an unsupported language (e.g. TypeScript).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0344c72476ea6122eb03a128cbda6b6735a713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->