### PR TITLE
Bump literalizer and expose expanded multiline support

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -469,16 +469,16 @@ Directive options
    ``single``
       Single-quoted strings.  Available for JavaScript.
    ``multiline``
-      Native multiline string syntax.  Available for Python (triple-quoted
-      strings), Java (text blocks), C++ and Rust (collision-free raw string
-      delimiters), C# (verbatim strings), Go (raw string literals), JavaScript
-      (template literals), Kotlin and Scala (triple-quoted strings), and Ruby
-      (multiline single-quoted strings).  Leading and trailing newlines, blank
-      lines, and embedded indentation are preserved.  When a native form
-      cannot safely represent a value, ``literalizer`` uses an escaped string
-      literal instead.  Java text blocks require Java 16, so selecting
-      ``multiline`` targets ``jdk_16`` even when ``:language-version: jdk_11``
-      is also specified.
+      Native multiline string syntax.  Available for C#, C++, Crystal, D,
+      Dart, Go, Groovy, Java, JavaScript, Kotlin, Lua, Nim, PHP, Python, Ruby,
+      Rust, Scala, Swift, and TypeScript.  The generated form follows the
+      language: for example, Java uses text blocks, C++ and Rust use
+      collision-free raw strings, and JavaScript and TypeScript use template
+      literals.  Leading and trailing newlines, blank lines, and embedded
+      indentation are preserved.  When a native form cannot safely represent
+      a value, ``literalizer`` uses an escaped string literal instead.  Java
+      text blocks require Java 16, so selecting ``multiline`` targets
+      ``jdk_16`` even when ``:language-version: jdk_11`` is also specified.
 
 For example, a small YAML dictionary can keep its message on multiple lines:
 
@@ -486,6 +486,14 @@ For example, a small YAML dictionary can keep its message on multiple lines:
    :language: python
    :include-delimiters:
    :string-format: multiline
+
+``:multiline-raw-string-delimiter-base:`` (optional)
+   Fallback delimiter base for C++ ``:string-format: multiline`` raw strings.
+   Literalizer first uses an empty delimiter when it does not collide with the
+   value.  On a collision, it tries this base and then numbered variants that
+   fit C++'s 16-character delimiter limit.  The default is ``x``.  The value
+   must be a non-empty sequence of valid C++ raw-string delimiter characters;
+   using this option with another language raises an error.
 
 ``:trailing-comma:`` (optional)
    Whether to include a trailing comma after the last element in

--- a/newsfragments/373.change
+++ b/newsfragments/373.change
@@ -1,0 +1,4 @@
+Adopt Literalizer's neutral C++ multiline raw-string delimiters, expose a
+configurable ``:multiline-raw-string-delimiter-base:``, and add multiline
+string support for Crystal, D, Dart, Groovy, Lua, Nim, PHP, Swift, and
+TypeScript.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.1",
+    "literalizer==2026.8.2",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -41,6 +41,7 @@ from literalizer.exceptions import (
     CommentSourceMultilineError,
     DottedCallTargetNotSupportedError,
     HeterogeneousCollectionError,
+    InvalidCppRawStringDelimiterError,
     InvalidRecordNameError,
     ParameterCountMismatchError,
     PerElementNotListError,
@@ -371,6 +372,7 @@ _COMMON_OPTIONS: dict[str, Callable[[str], Any]] = {
     "default-dict-value-type": directives.unchanged,
     "default-ordered-map-value-type": directives.unchanged,
     "module-name": directives.unchanged,
+    "multiline-raw-string-delimiter-base": directives.unchanged_required,
     "record-struct-name-prefix": directives.unchanged_required,
     "record-shape-names": directives.unchanged_required,
     "heterogeneous-value-name": directives.unchanged_required,
@@ -470,6 +472,7 @@ _USER_FACING_LITERALIZER_ERRORS: tuple[type[Exception], ...] = (
     CommentSourceMultilineError,
     DottedCallTargetNotSupportedError,
     HeterogeneousCollectionError,
+    InvalidCppRawStringDelimiterError,
     InvalidRecordNameError,
     PerElementNotListError,
     UnrepresentableEmptyDictError,
@@ -526,6 +529,7 @@ class _CommonOptions:
     heterogeneous_strategy: str | None
     default_type_options: Mapping[str, str]
     module_name: str | None
+    multiline_raw_string_delimiter_base: str | None
     record_struct_name_prefix: str | None
     record_shape_names: str | None
     heterogeneous_value_name: str | None
@@ -585,6 +589,7 @@ class _CommonOptionArgs(TypedDict):
     heterogeneous_strategy: str | None
     default_type_options: Mapping[str, str]
     module_name: str | None
+    multiline_raw_string_delimiter_base: str | None
     record_struct_name_prefix: str | None
     record_shape_names: str | None
     heterogeneous_value_name: str | None
@@ -626,6 +631,9 @@ def _common_option_args(options: dict[str, Any]) -> _CommonOptionArgs:
             if name in options
         },
         module_name=options.get("module-name"),
+        multiline_raw_string_delimiter_base=options.get(
+            "multiline-raw-string-delimiter-base"
+        ),
         record_struct_name_prefix=options.get("record-struct-name-prefix"),
         record_shape_names=options.get("record-shape-names"),
         heterogeneous_value_name=options.get("heterogeneous-value-name"),
@@ -758,6 +766,28 @@ class _BaseLiteralizerDirective(SphinxDirective):  # pylint: disable=abstract-me
                 )
         return constructor
 
+    @staticmethod
+    def _apply_multiline_raw_string_delimiter_base(
+        language_name: str,
+        constructor: partial[Language],
+        *,
+        options: _CommonOptions,
+    ) -> partial[Language]:
+        """Apply the C++ multiline raw-string delimiter base."""
+        delimiter_base = options.multiline_raw_string_delimiter_base
+        if delimiter_base is None:
+            return constructor
+        if language_name != "cpp":
+            msg = (
+                f"Language '{language_name}' does not support "
+                "':multiline-raw-string-delimiter-base:'."
+            )
+            raise ExtensionError(message=msg)
+        return partial(
+            constructor,
+            multiline_raw_string_delimiter_base=delimiter_base,
+        )
+
     def _build_language(
         self,
         language_name: str,
@@ -792,6 +822,11 @@ class _BaseLiteralizerDirective(SphinxDirective):  # pylint: disable=abstract-me
             heterogeneous_strategy_value=heterogeneous_strategy_value,
         )
         constructor = self._apply_default_type_options(
+            language_name=language_name,
+            constructor=constructor,
+            options=options,
+        )
+        constructor = self._apply_multiline_raw_string_delimiter_base(
             language_name=language_name,
             constructor=constructor,
             options=options,

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3097,6 +3097,15 @@ def test_string_format_multiline_native_delimiters(
         "ruby",
         "scala",
         "rust",
+        "crystal",
+        "d",
+        "dart",
+        "groovy",
+        "lua",
+        "nim",
+        "php",
+        "swift",
+        "typescript",
     )
     directives = "\n\n".join(
         f".. literalizer:: data.json\n"
@@ -3121,9 +3130,9 @@ def test_string_format_multiline_native_delimiters(
         for literal_block in doctree.findall(condition=nodes.literal_block)
     ]
     assert actual == [
-        '"""first\n\n  indented\nlast"""',
+        '"""\\\nfirst\n\n  indented\nlast"""',
         '"""\nfirst\n\n  indented\nlast"""',
-        'R"LITERALIZER(first\n\n  indented\nlast)LITERALIZER"',
+        'R"(first\n\n  indented\nlast)"',
         '@"first\n\n  indented\nlast"',
         "`first\n\n  indented\nlast`",
         "`first\n\n  indented\nlast`",
@@ -3131,8 +3140,122 @@ def test_string_format_multiline_native_delimiters(
         "'first\n\n  indented\nlast'",
         '"""first\n\n  indented\nlast"""',
         'r#"first\n\n  indented\nlast"#',
+        "%q|first\n\n  indented\nlast|",
+        "`first\n\n  indented\nlast`",
+        "'''first\n\n  indented\nlast'''",
+        "'''first\n\n  indented\nlast'''",
+        "[[first\n\n  indented\nlast]]",
+        '"""first\n\n  indented\nlast"""',
+        "'first\n\n  indented\nlast'",
+        '#"""\nfirst\n\n  indented\nlast\n"""#',
+        "`first\n\n  indented\nlast`",
     ]
     app.cleanup()
+
+
+def test_cpp_multiline_raw_string_delimiters(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """C++ uses neutral delimiters and accepts a custom fallback base."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj='first\n)"\nlast'),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: cpp
+           :string-format: multiline
+
+        .. literalizer:: data.json
+           :language: cpp
+           :string-format: multiline
+           :multiline-raw-string-delimiter-base: TAG
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    actual = [
+        literal_block.astext()
+        for literal_block in doctree.findall(condition=nodes.literal_block)
+    ]
+    assert actual == [
+        'R"x(first\n)"\nlast)x"',
+        'R"TAG(first\n)"\nlast)TAG"',
+    ]
+    assert "LITERALIZER" not in "".join(actual)
+    app.cleanup()
+
+
+@pytest.mark.parametrize(
+    argnames=("language", "delimiter_base", "match"),
+    argvalues=[
+        (
+            "python",
+            "TAG",
+            (
+                r"Language 'python' does not support "
+                r"':multiline-raw-string-delimiter-base:'\."
+            ),
+        ),
+        (
+            "cpp",
+            "(",
+            r"Cpp multiline_raw_string_delimiter_base .* is invalid",
+        ),
+    ],
+)
+def test_multiline_raw_string_delimiter_base_error(
+    language: str,
+    delimiter_base: str,
+    match: str,
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """The C++-only delimiter option reports invalid uses cleanly."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj="first\nsecond"),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text=f"""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: {language}
+           :string-format: multiline
+           :multiline-raw-string-delimiter-base: {delimiter_base}
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    with pytest.raises(expected_exception=ExtensionError, match=match):
+        app.build()
 
 
 def test_string_format_multiline_preserves_edge_newlines(
@@ -3169,7 +3292,9 @@ def test_string_format_multiline_preserves_edge_newlines(
 
     doctree = app.env.get_doctree(docname="index")
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
-    assert literal_block.astext() == ('"""\nfirst\n\n  indented\nlast\n"""')
+    assert literal_block.astext() == (
+        '"""\\\n\nfirst\n\n  indented\nlast\n"""'
+    )
     app.cleanup()
 
 
@@ -3211,7 +3336,7 @@ def test_string_format_multiline_literalizer_call_yaml(
     doctree = app.env.get_doctree(docname="index")
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
     assert literal_block.astext() == (
-        'emit(message="""first\n\n  indented\nlast\n""")'
+        'emit(message="""\\\nfirst\n\n  indented\nlast\n""")'
     )
     app.cleanup()
 
@@ -3274,7 +3399,7 @@ def test_unsupported_string_format_multiline_error(
         ====
 
         .. literalizer:: data.json
-           :language: typescript
+           :language: c
            :string-format: multiline
     """
         )
@@ -3287,7 +3412,7 @@ def test_unsupported_string_format_multiline_error(
     with pytest.raises(
         expected_exception=ExtensionError,
         match=(
-            r"Language 'typescript' does not support string-format "
+            r"Language 'c' does not support string-format "
             r"'multiline'\."
         ),
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.1"
+version = "2026.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -784,9 +784,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/31/66edaa935833129ee7677556f238f7c8664ebe7c7d95cfa26645d8d3771e/literalizer-2026.8.1.tar.gz", hash = "sha256:4aa327de7ca26cadfa28e4810e59e11110a0d7a139a4934a3cbce66e3f563539", size = 3762945, upload-time = "2026-08-01T13:41:44.567Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/6a/9dbadcf45a71a496e20211021d824a6a5cc13bc4ff433faaf71331ef6e36/literalizer-2026.8.2.tar.gz", hash = "sha256:e84374c53b465bf53e7c4a9381c50c866f7bd9d00ea7628ac81ed53c4f742c71", size = 3771422, upload-time = "2026-08-02T08:56:57.079Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/53/974b424d575f33fdab9ae1db1da9ef866a496649d126370dea22dc2c6fe8/literalizer-2026.8.1-py3-none-any.whl", hash = "sha256:1f11b5d418d9977002bd55942cabd35b3a270687887586583f4d2ff6b12b7e69", size = 859245, upload-time = "2026-08-01T13:41:42.713Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4e/41e87d9677932d54e53192729a1bea84bb1d9c8ba389eaa8854dc9ecb8ef/literalizer-2026.8.2-py3-none-any.whl", hash = "sha256:ecdc5cefd69e33c856832bfc6073b77535935ebe6ec224e7d51817e7aad8da30", size = 863054, upload-time = "2026-08-02T08:56:55.622Z" },
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.1" },
+    { name = "literalizer", specifier = "==2026.8.2" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.11" },


### PR DESCRIPTION
## Summary

Bump Literalizer to 2026.8.2 and expose native multiline strings for Crystal, D, Dart, Groovy, Lua, Nim, PHP, Swift, and TypeScript.
Add the C++-only `:multiline-raw-string-delimiter-base:` option and adopt neutral raw-string delimiters, removing the previous `LITERALIZER` branding while retaining collision-safe fallbacks.
Update the directive documentation, lockfile, news fragment, and end-to-end coverage for expanded formats, delimiter collisions, custom bases, and validation errors.

## Validation

All pre-commit, pre-push, and manual hooks pass, the documentation builds warning-free, and 225 tests pass with 100% coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Sphinx directive wiring around an optional C++ formatting knob; behavior is covered by extended integration tests with no security-sensitive paths.
> 
> **Overview**
> **Bumps `literalizer` to 2026.8.2** and documents broader `:string-format: multiline` coverage (Crystal, D, Dart, Groovy, Lua, Nim, PHP, Swift, TypeScript, and others).
> 
> Adds the C++-only Sphinx option **`:multiline-raw-string-delimiter-base:`**, wired through `_apply_multiline_raw_string_delimiter_base` so collision fallbacks for multiline raw strings can use a custom delimiter base (default `x`). Using it on non-C++ languages or with an invalid delimiter surfaces **`ExtensionError`** via **`InvalidCppRawStringDelimiterError`**.
> 
> C++ multiline output now uses **neutral raw-string delimiters** (e.g. `R"(...)"` / `R"x(...)x"`) instead of branded `LITERALIZER` delimiters. Test expectations are updated for literalizer’s revised multiline escaping (e.g. Python `"""\\\n..."""`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746c99daea25085a72434d7c319a72818fffcba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->