### PR TITLE
Run C++14 owning carrier regression

### DIFF
--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7893,8 +7893,14 @@ def test_literalizer_call_named_carrier_preamble_only(
         'TaskValue{1}, TaskValue{"fast"}, TaskValue{nullptr}});'
     )
     combined = (
+        "#include <cassert>\n\n"
         f"{preamble_block.astext()}\n\n"
-        "void run(const std::string&, const std::vector<TaskValue>&) {}\n\n"
+        "void run(const std::string&, "
+        "const std::vector<TaskValue>& values) {\n"
+        "    assert(values.at(1).is<std::string>());\n"
+        '    assert(values.at(1).get<std::string>() == "fast");\n'
+        "    assert(!values.at(1).is<const char*>());\n"
+        "}\n\n"
         "int main() {\n"
         f"    {call_block.astext()}\n"
         "    return 0;\n"
@@ -7903,13 +7909,21 @@ def test_literalizer_call_named_carrier_preamble_only(
     assert combined.count("struct TaskValue {") == 1
     combined_path = tmp_path / "combined.cpp"
     combined_path.write_text(data=combined)
+    executable_path = tmp_path / "combined"
     subprocess.run(
         args=[
             compiler,
             "-std=c++14",
-            "-fsyntax-only",
             str(object=combined_path),
+            "-o",
+            str(object=executable_path),
         ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        args=[str(object=executable_path)],
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
Closes #356.

## What changed

Extends the existing Sphinx-level named-carrier integration test into a compiled and executed C++14 regression. The generated program now verifies that the parsed string carrier:

- reports `is<std::string>()` as true;
- returns `"fast"` from `get<std::string>()`; and
- reports `is<const char*>()` as false.

## Why

Literalizer 2026.7.24.1 and its owning-string output were already adopted in #357, but #356 also requires candidate-facing runtime proof and execution of the composed generated program. The prior test only compiled with `-fsyntax-only`.

## Validation

- `uv run --extra dev pytest -q` — 225 passed
- commit and pre-push hooks — passed
- generated program compiled with `-std=c++14` and executed by the regression test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code paths; slightly increases CI reliance on a working C++ compiler and successful program execution.
> 
> **Overview**
> The C++14 named-carrier integration test (`test_cpp14_named_carrier_preamble_only`) no longer stops at **syntax-only** compilation. It now builds a full executable and runs it.
> 
> The stitched test program adds **`#include <cassert>`** and a **`run`** stub that checks the middle `TaskValue` element: `is<std::string>()` is true, `get<std::string>()` is `"fast"`, and `is<const char*>()` is false. Compilation uses `-std=c++14` with `-o` instead of `-fsyntax-only`, followed by executing the binary so runtime behavior of the owning string carrier is validated, not just generated code shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46af78144c96ecfc1be670f95af15ba6b0d7b4b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->