### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -289,6 +289,15 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies: [*uv_version]
+        stages: [pre-commit]
+        require_serial: true
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8
@@ -374,10 +383,4 @@ repos:
         language: python
         types_or: [rst]
         additional_dependencies: [*uv_version]
-        stages: [pre-commit]
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -375,3 +375,9 @@ repos:
         types_or: [rst]
         additional_dependencies: [*uv_version]
         stages: [pre-commit]
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -377,7 +377,7 @@ repos:
         stages: [pre-commit]
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ lint.per-file-ignores."tests/test_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [ "NOD" ]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.mccabe.max-complexity = 12
 lint.pydocstyle.convention = "google"
@@ -469,3 +470,7 @@ linewrap-full-docstring = true
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pylint[spelling]==4.0.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1064,6 +1064,17 @@ wheels = [
 ]
 
 [[package]]
+name = "no-defaults"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/54/3454e62945b092758b587e0e4b7cf35aa77f88da5fc43f20790bf5d433ad/no_defaults-1.0.1.tar.gz", hash = "sha256:c309ae30960a08ebc2436e7a45aeea46b5eb1c73c65bf02220e41e5b5d01721c", size = 28426, upload-time = "2026-08-05T22:15:00.523Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/de/1e7659c6ce5babd9fa57c14463e2b50536b9d6d1754f58db0f0307da6986/no_defaults-1.0.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4584dff7a7bdf632ccff600bae628276ba66a9ede156808e55e6c9c411982d4f", size = 2034147, upload-time = "2026-08-05T22:14:55.306Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2c/ff7f38b88649560ca6d18a0a5652c30f969438f0a8d993991825ba8c7ee9/no_defaults-1.0.1-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:da5ed90cedddebddfbda4bd3fa180eba42b39814e118b7f297cd6f7705edb6a7", size = 2206221, upload-time = "2026-08-05T22:14:57.542Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a0/66a4ac44d0216e88e924e54756cee8282f4f04f646c02c5931b7f9bed933/no_defaults-1.0.1-py3-none-win_amd64.whl", hash = "sha256:31c9f3252b54d5e04e061f7aaf3b08571236eec5db1f20be91cc3cbf4be92827", size = 1931806, upload-time = "2026-08-05T22:14:59.254Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2067,6 +2078,7 @@ dev = [
     { name = "interrogate" },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "mypy-strict-kwargs" },
+    { name = "no-defaults" },
     { name = "prek" },
     { name = "pydocstringformatter" },
     { name = "pylint", extra = ["spelling"] },
@@ -2118,6 +2130,7 @@ requires-dist = [
     { name = "literalizer", specifier = "==2026.8.2" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
+    { name = "no-defaults", marker = "extra == 'dev'", specifier = "==1.0.1" },
     { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.11" },
     { name = "pydocstringformatter", marker = "extra == 'dev'", specifier = "==1.0.0" },
     { name = "pylint", extras = ["spelling"], marker = "extra == 'dev'", specifier = "==4.0.6" },


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and lint-policy only; no runtime or application logic changes in this diff.
> 
> **Overview**
> Introduces **`no-defaults`** (v1.0.1) as a dev dependency and a **pre-commit** hook (`uv run --extra=dev no-defaults`), placed alongside the existing `strict-kwargs` hook with serial execution.
> 
> Configures **`[tool.no_defaults]`** so defaults are banned in **`tests/**`** everywhere, while non-test code only enforces **`private_only`** (private functions/classes/modules).
> 
> Registers Ruff **`lint.external = ["NOD"]`** so `# noqa: NOD001`-style suppressions are valid when baselining existing defaults.
> 
> Lockfile updated for the new package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae9473ef97fa53267e7180b96879d6ef8958959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->