### PR TITLE
Bump literalizer to 2026.8.12.2

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -768,6 +768,19 @@ This option is available only for languages and JSON-value variants that
 ``literalizer`` supports.  Use ``:include-preamble:`` when the generated
 snippet also needs its imports.
 
+``:json-rendering:`` (optional, C++ only) chooses how ``:json-type:`` values are rendered.
+The default renders structural ``nlohmann::json`` factory expressions.
+``:json-rendering: inline_document`` instead renders the whole value as one inline JSON document handed to ``nlohmann::json::parse`` in a ``R"json(...)json"`` raw string, honoring ``:collection-layout:``, so readers see the data as JSON at the cost of the structural form's compile-time validation.
+It requires ``:json-type:``, and rejects non-finite floats and integers outside ``[-2^63, 2^64 - 1]`` because a JSON document cannot carry them exactly.
+
+.. literalizer-call:: _examples/calls_json.json
+   :language: cpp
+   :target-function: process
+   :parameter-names: profile,labels
+   :per-element:
+   :json-type: nlohmann_json
+   :json-rendering: inline_document
+
 Heterogeneous call arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/newsfragments/403.change
+++ b/newsfragments/403.change
@@ -1,0 +1,2 @@
+Bump ``literalizer`` to 2026.8.12.2.
+The new ``:json-rendering:`` option (C++ only) chooses how ``:json-type:`` values are rendered: ``:json-rendering: inline_document`` renders the whole value as one inline JSON document handed to ``nlohmann::json::parse`` in a ``R"json(...)json"`` raw string instead of the default structural ``nlohmann::json`` factory expressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.12.1",
+    "literalizer==2026.8.12.2",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -119,6 +119,10 @@ _FORMAT_OPTION_GETTERS: dict[
     "heterogeneous-strategy": lambda cls: cls.HeterogeneousStrategies,
     "call-style": lambda cls: cls.CallStyles,
     "json-type": lambda cls: cls.JsonTypes,
+    "json-rendering": lambda cls: _language_owned_enum(
+        lang_cls=cls,
+        name="JsonRenderings",
+    ),
     "bool-format": lambda cls: cls.BoolFormats,
     "annotation-evaluation": lambda cls: _language_owned_enum(
         lang_cls=cls,
@@ -143,11 +147,13 @@ _FORMAT_OPTION_SUPPORTS_CHECKS: dict[str, Callable[[LanguageCls], bool]] = {
     "call-style": lambda cls: cls.supports_call_style,
     "annotation-evaluation": lambda cls: "AnnotationEvaluations" in vars(cls),
     "union-format": lambda cls: "UnionFormats" in vars(cls),
+    "json-rendering": lambda cls: "JsonRenderings" in vars(cls),
 }
 
 _FORMAT_OPTION_ENUM_CHECKS: dict[str, Callable[[LanguageCls], bool]] = {
     "annotation-evaluation": lambda cls: "AnnotationEvaluations" in vars(cls),
     "union-format": lambda cls: "UnionFormats" in vars(cls),
+    "json-rendering": lambda cls: "JsonRenderings" in vars(cls),
 }
 
 
@@ -1181,6 +1187,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :empty-dict-key: positional
            :heterogeneous-strategy: auto
            :json-type: serde_json_value
+           :json-rendering: inline_document
            :bool-format: json_pp_ref
            :default-set-element-type: String
            :default-sequence-element-type: String

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -9771,6 +9771,139 @@ def test_json_type_rejected_for_unsupported_language(
     app.cleanup()
 
 
+def test_json_rendering_cpp_inline_document(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:json-rendering: inline_document`` renders the C++ JSON value
+    as one inline JSON document handed to ``nlohmann::json::parse``
+    instead of structural ``nlohmann::json`` factory expressions.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1, "b": "two"}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: cpp
+           :json-type: nlohmann_json
+           :json-rendering: inline_document
+           :variable-name: data
+           :include-delimiters:
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == (
+        'auto data = nlohmann::json::parse(R"json({\n'
+        '    "a": 1,\n'
+        '    "b": "two"\n'
+        '})json");'
+    )
+    app.cleanup()
+
+
+def test_json_rendering_rejected_for_unsupported_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A language without a ``JsonRenderings`` enum (e.g. Python)
+    surfaces a clean directive error rather than crashing on the
+    constructor kwarg.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :json-rendering: inline_document
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    _assert_directive_error(
+        app=app,
+        source_directory=source_directory,
+        line=4,
+        message="Language 'python' does not support 'json-rendering'.",
+    )
+    app.cleanup()
+
+
+def test_json_rendering_requires_json_type(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:json-rendering:`` without ``:json-type:`` surfaces
+    literalizer's validation error against the directive.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: cpp
+           :json-rendering: inline_document
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    _assert_directive_error(
+        app=app,
+        source_directory=source_directory,
+        line=4,
+        message=(
+            "Cpp json_rendering selects how json_type values are "
+            "rendered and requires json_type to be set."
+        ),
+    )
+    app.cleanup()
+
+
 def test_error_reports_directive_line(
     *,
     make_app: Callable[..., SphinxTestApp],

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.12.1"
+version = "2026.8.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/df/66ee7f0eaeba00ddf52782844ec3c182a2e4ba8bae70da2a41fc7b8879a3/literalizer-2026.8.12.1.tar.gz", hash = "sha256:704bc365e235b69b912cab416c150de8618fe50b606e90e21924e36d10f9def9", size = 4033499, upload-time = "2026-08-12T13:42:45.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/db/36653e2345b67b9b895b0016b02c94dde05e19c5e2f1c39289d6296eb894/literalizer-2026.8.12.2.tar.gz", hash = "sha256:c58eb47cc84afa1c3e9b187d184681f625711b36a72932b361c049dfca746cce", size = 4039416, upload-time = "2026-08-12T16:09:01.999Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/63/46d0ed89db6e809b112ff989b737b9a1038b39f56867fc5127e3ecfce8b6/literalizer-2026.8.12.1-py3-none-any.whl", hash = "sha256:2486077ad7c33c710aaa8901bb1c9d4b62b83587c233e2862e5a28fa21b96e90", size = 871855, upload-time = "2026-08-12T13:42:42.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/18/7b3f20bdba5d138b26a7b137e50dc93fc308798ff69d26513bbc4a78130e/literalizer-2026.8.12.2-py3-none-any.whl", hash = "sha256:f4df243271e0f7bf5f825dce3149dcbb99d676565c83673e2cce6cb771a10057", size = 874047, upload-time = "2026-08-12T16:08:59.694Z" },
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.12.1" },
+    { name = "literalizer", specifier = "==2026.8.12.2" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Bump `literalizer` to 2026.8.12.2 and expose its new opt-in C++ `json_rendering` constructor argument as a `:json-rendering:` directive option.

`:json-rendering: inline_document` with `:json-type: nlohmann_json` renders the value as one inline JSON document handed to `nlohmann::json::parse` in a `R"json(...)json"` raw string, honoring `:collection-layout:`, instead of the default structural `nlohmann::json` factory expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency bump plus a new optional directive option gated to C++ with clear validation; behavior change is opt-in via `:json-rendering:`.
> 
> **Overview**
> Bumps the **`literalizer`** dependency to **2026.8.12.2** and wires its new C++ **`json_rendering`** knob through Sphinx as **`:json-rendering:`** on `literalizer` / `literalizer-call`.
> 
> **`:json-rendering: inline_document`** (with **`:json-type:`**, C++ only) switches nlohmann JSON output from structural factory calls to a single **`nlohmann::json::parse`** over a **`R"json(...)json"`** raw string, respecting **`:collection-layout:`**. Docs describe defaults, constraints (requires **`:json-type:`**; rejects non-finite floats and out-of-range integers), and add a C++ example.
> 
> Extension changes mirror other language-owned format options: map **`JsonRenderings`**, gate languages without that enum, and add tests for happy path, unsupported language, and missing **`:json-type:`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf05b9bef610d9f834896b42b53619afe03f0ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->