### PR TITLE
Bump literalizer to 2026.8.12.3

### DIFF
--- a/newsfragments/404.change
+++ b/newsfragments/404.change
@@ -1,0 +1,2 @@
+Bump ``literalizer`` to 2026.8.12.3.
+Strings with embedded NUL bytes now render valid target-language literals, and C++ ``:json-type: nlohmann_json`` structural output honors ``:collection-layout: multiline`` under a variable form.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.12.2",
+    "literalizer==2026.8.12.3",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.12.2"
+version = "2026.8.12.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/db/36653e2345b67b9b895b0016b02c94dde05e19c5e2f1c39289d6296eb894/literalizer-2026.8.12.2.tar.gz", hash = "sha256:c58eb47cc84afa1c3e9b187d184681f625711b36a72932b361c049dfca746cce", size = 4039416, upload-time = "2026-08-12T16:09:01.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f9/c3ee6a952c0b70b006eb6e19976898519d19429f75af479189cd1f2eab9b/literalizer-2026.8.12.3.tar.gz", hash = "sha256:a88ab7effe6ec5587a105038e575e2ec5d066764058b3d30391ec5ba9d7734e9", size = 4055128, upload-time = "2026-08-12T16:33:44.277Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/18/7b3f20bdba5d138b26a7b137e50dc93fc308798ff69d26513bbc4a78130e/literalizer-2026.8.12.2-py3-none-any.whl", hash = "sha256:f4df243271e0f7bf5f825dce3149dcbb99d676565c83673e2cce6cb771a10057", size = 874047, upload-time = "2026-08-12T16:08:59.694Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/52/12c0765d78ebdf07d4de764c1477baf16a6cba76e0f64f6ee0794bf3cb38/literalizer-2026.8.12.3-py3-none-any.whl", hash = "sha256:06b4fabe77c433eaa9adceabc4c52276a83b4093f4bc03963465ef48ec556a14", size = 876168, upload-time = "2026-08-12T16:33:42.663Z" },
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.12.2" },
+    { name = "literalizer", specifier = "==2026.8.12.3" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Bump `literalizer` to 2026.8.12.3.

User-visible changes flowing through from literalizer:
- Strings with embedded NUL bytes now render valid target-language literals instead of invalid source.
- C++ `:json-type: nlohmann_json` structural output honors `:collection-layout: multiline` under a variable form.
- A known constructor option unsupported by the selected language now raises a typed `UnsupportedOptionError`; the extension's existing `LiteralizerError` handling already reports it as a clean directive error, and its own per-option pre-checks remain the first line of defence.

No extension code changes are needed; the full test suite passes unchanged against the new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no extension code changes; existing tests pass unchanged against the new literalizer release.
> 
> **Overview**
> Bumps the **`literalizer`** dependency from `2026.8.12.2` to **`2026.8.12.3`** in `pyproject.toml` and `uv.lock`, with a matching **towncrier** news fragment. There are **no changes** to the Sphinx extension itself.
> 
> User-visible behavior comes from the new **literalizer** release: strings with embedded **NUL** bytes produce valid target-language literals; C++ **`:json-type: nlohmann_json`** output respects **`:collection-layout: multiline`** in variable form; unsupported constructor options for the chosen language surface as **`UnsupportedOptionError`**, which existing **`LiteralizerError`** handling already turns into a clear directive error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4863f7fb3a5ad4f7ce08016088399af7c1a85f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->