### PR TITLE
Bump literalizer to 2026.8.12.4

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -808,6 +808,8 @@ A directive that cannot render its data -- because of an option the language doe
 Such an error does not stop the build, so one run reports every failing block rather than only the first.
 Build with ``-W`` to turn these errors into a build failure.
 
+When an error concerns one particular value in the data file, the message ends with that value's input path -- for example ``(at input path 'tasks[0].items')`` -- so the offending value can be found without searching the whole file.
+
 Problems that are not attributable to a directive, such as an invalid value for one of the configuration settings below, still fail the build immediately.
 
 

--- a/newsfragments/406.change
+++ b/newsfragments/406.change
@@ -1,0 +1,2 @@
+Bump ``literalizer`` to 2026.8.12.4.
+When an error concerns one particular value in the data file, the directive error message now ends with that value's input path -- for example ``(at input path 'tasks[0].items')`` -- so the offending value can be found without searching the whole file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.12.3",
+    "literalizer==2026.8.12.4",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -467,6 +467,24 @@ _EXTENSION_TO_INPUT_FORMAT: dict[str, InputFormat] = {
 }
 
 
+def _format_input_path(*, path: tuple[str | int, ...]) -> str:
+    """Render a literalizer input path as a compact locator string.
+
+    Mapping keys join with ``.`` and zero-based sequence indexes render
+    as ``[N]``, so the offending value in ``{"tasks": [{"name": ...}]}``
+    is located as ``tasks[0].name``.
+    """
+    rendered = ""
+    for element in path:
+        if isinstance(element, int):
+            rendered += f"[{element}]"
+        elif rendered:
+            rendered += f".{element}"
+        else:
+            rendered = element
+    return rendered
+
+
 @contextmanager
 def _literalize_errors_as_directive_errors() -> Generator[None]:
     """Convert user-facing literalizer exceptions into
@@ -488,7 +506,13 @@ def _literalize_errors_as_directive_errors() -> Generator[None]:
     except ParameterCountMismatchError:
         raise
     except LiteralizerError as exc:
-        raise _DirectiveError(message=str(object=exc)) from exc
+        message = str(object=exc)
+        # ``path`` locates the offending value within the input data
+        # (``None`` or empty when the error concerns the whole input).
+        if exc.path:
+            locator = _format_input_path(path=exc.path)
+            message = f"{message} (at input path '{locator}')"
+        raise _DirectiveError(message=message) from exc
 
 
 @beartype

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -9062,7 +9062,7 @@ def test_concrete_heterogeneous_strategy_unrepresentable_error(
         message=(
             "Dict has values of mixed type families including a "
             "container, which this heterogeneous strategy cannot "
-            "represent"
+            "represent (at input path '[0]')"
         ),
     )
 
@@ -9899,6 +9899,55 @@ def test_json_rendering_requires_json_type(
         message=(
             "Cpp json_rendering selects how json_type values are "
             "rendered and requires json_type to be set."
+        ),
+    )
+    app.cleanup()
+
+
+def test_error_reports_input_path(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """An error tied to one input value reports that value's path.
+
+    literalizer attaches the offending value's input path to its
+    errors; the directive error appends it as a compact locator so an
+    author can find the value in a large data file.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(
+            obj={"tasks": [{"name": "a", "items": [1, "two"]}]},
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: error
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    _assert_directive_error(
+        app=app,
+        source_directory=source_directory,
+        line=4,
+        message=(
+            "Collection contains heterogeneous scalar types that cannot "
+            "be represented in the target language (found types: int, "
+            "str) (at input path 'tasks[0].items')"
         ),
     )
     app.cleanup()

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.12.3"
+version = "2026.8.12.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/f9/c3ee6a952c0b70b006eb6e19976898519d19429f75af479189cd1f2eab9b/literalizer-2026.8.12.3.tar.gz", hash = "sha256:a88ab7effe6ec5587a105038e575e2ec5d066764058b3d30391ec5ba9d7734e9", size = 4055128, upload-time = "2026-08-12T16:33:44.277Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/05/2314cfbc67ac978a9c2bb2b9c23f468f57b891aa0cd4c7e626082d2a0a71/literalizer-2026.8.12.4.tar.gz", hash = "sha256:a5516b96f883fe9819d3fb09f65076a15392bcf4af646a2ffb125400937fa599", size = 4058287, upload-time = "2026-08-12T21:42:29.048Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/52/12c0765d78ebdf07d4de764c1477baf16a6cba76e0f64f6ee0794bf3cb38/literalizer-2026.8.12.3-py3-none-any.whl", hash = "sha256:06b4fabe77c433eaa9adceabc4c52276a83b4093f4bc03963465ef48ec556a14", size = 876168, upload-time = "2026-08-12T16:33:42.663Z" },
+    { url = "https://files.pythonhosted.org/packages/11/96/a93add655fbd89a247f62a64ee7363c9285b10b961382fb92535ced5ce16/literalizer-2026.8.12.4-py3-none-any.whl", hash = "sha256:94cd3ffb4f752c3abcda73dfe776ffa8a6ec629a53311d3a59b9c0381a319f46", size = 878145, upload-time = "2026-08-12T21:42:27.251Z" },
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.12.3" },
+    { name = "literalizer", specifier = "==2026.8.12.4" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Bump `literalizer` to 2026.8.12.4 and surface its new structured error locations.

literalizer now attaches the offending value's input `path` to validation and renderer errors. Directive errors append it as a compact locator — e.g. `Collection contains heterogeneous scalar types ... (at input path 'tasks[0].items')` — so an author can find the value in a large data file without searching. Parse errors already carry line/column in their message text, so those needed no change.

Also flows through from the release: Bash string-fidelity fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin bump plus localized error-message formatting in the existing literalizer exception handler; no auth, data, or API surface changes beyond clearer build diagnostics.
> 
> **Overview**
> **Bumps `literalizer` to 2026.8.12.4** (lockfile included). The upstream release adds a `path` on validation/renderer errors and Bash string-fidelity fixes; this PR wires the path into Sphinx-facing errors.
> 
> When a `LiteralizerError` carries a non-empty `path`, `_literalize_errors_as_directive_errors` now suffixes the message with **`(at input path '…')`**, using new **`_format_input_path`** (dot-separated keys, `[N]` for list indices). Whole-input errors are unchanged. Docs and a news fragment describe the locator; tests cover nested paths like `tasks[0].items` and update an existing heterogeneous-strategy expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b727bfa39f300f61bde5f86ed14d4c78c725b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->