### PR TITLE
Bump literalizer to 2026.8.12.5

### DIFF
--- a/newsfragments/407.change
+++ b/newsfragments/407.change
@@ -1,0 +1,2 @@
+Bump ``literalizer`` to 2026.8.12.5.
+Public literalizer exceptions now carry structured input paths and parser line and column positions, and every language declares explicit round-trip capability metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.12.4",
+    "literalizer==2026.8.12.5",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.12.4"
+version = "2026.8.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/05/2314cfbc67ac978a9c2bb2b9c23f468f57b891aa0cd4c7e626082d2a0a71/literalizer-2026.8.12.4.tar.gz", hash = "sha256:a5516b96f883fe9819d3fb09f65076a15392bcf4af646a2ffb125400937fa599", size = 4058287, upload-time = "2026-08-12T21:42:29.048Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/3d/ecfef83d11d6a91f686c75a77c73eff3e31c887766675e70541b24aa0f13/literalizer-2026.8.12.5.tar.gz", hash = "sha256:b8c91ca131148fb3821c86f0e22bb8e9062979decff1a6d39ae0cf78d3b003da", size = 4068013, upload-time = "2026-08-12T23:21:55.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/96/a93add655fbd89a247f62a64ee7363c9285b10b961382fb92535ced5ce16/literalizer-2026.8.12.4-py3-none-any.whl", hash = "sha256:94cd3ffb4f752c3abcda73dfe776ffa8a6ec629a53311d3a59b9c0381a319f46", size = 878145, upload-time = "2026-08-12T21:42:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/47/70/8650f105a32f3da7354e6d10127c3ba046cfbd65e873c6be9b2d54c3a761/literalizer-2026.8.12.5-py3-none-any.whl", hash = "sha256:b687558c01109f8c30b48d545866272b035a1752b849ab8238563c248ed51907", size = 885309, upload-time = "2026-08-12T23:21:54.041Z" },
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.12.4" },
+    { name = "literalizer", specifier = "==2026.8.12.5" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Picks up literalizer 2026.08.12.5:

- Structured input paths and parser line and column positions on public exceptions (adamtheturtle/literalizer#3593).
- Explicit round-trip capability metadata on every language.

No extension changes were needed; all tests pass unchanged.
The exception-position attributes unblock #397, addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and version pin only; no application logic changes in this repository.
> 
> **Overview**
> Bumps the pinned **`literalizer`** dependency from `2026.8.12.4` to **`2026.8.12.5`** in `pyproject.toml` and **`uv.lock`**, with a matching **towncrier** news fragment.
> 
> This release brings **structured input paths** and **parser line/column positions** on public literalizer exceptions, plus **explicit round-trip capability metadata** on every language. **No sphinx-literalizer source changes** are included; the extension is expected to keep passing tests as-is, with the richer exception fields intended to support follow-up work (e.g. issue #397).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872a16b17a3876edfcc0a092d827ede5880cc87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->