### PR TITLE
Report the parser's position for malformed data files

### DIFF
--- a/newsfragments/408.change
+++ b/newsfragments/408.change
@@ -1,0 +1,1 @@
+A malformed data file now reports the underlying parser's line and column alongside the directive error, for example ``Invalid JSON: Expecting value at line 3 column 1 (at line 3, column 1 of the data file)``.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -68,6 +68,7 @@ mojo
 multiline
 norg
 overridable
+parser's
 php
 positionally
 pragma

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -37,6 +37,7 @@ from literalizer.exceptions import (
     HeterogeneousCollectionError,
     LiteralizerError,
     ParameterCountMismatchError,
+    ParseError,
     UnrepresentableEmptyDictError,
     UnrepresentableInputError,
     UnrepresentableIntegerError,
@@ -497,6 +498,10 @@ def _literalize_errors_as_directive_errors() -> Generator[None]:
     the build report the offending directive's document and line and
     carry on with the rest of the build.
 
+    A ``ParseError`` carrying a parser position reports it alongside the
+    message, so a malformed data file is located by its own line and
+    column rather than only by the directive that read it.
+
     ``ParameterCountMismatchError`` propagates unchanged: the
     ``literalizer-call`` directive catches it itself to add the
     ``:parameter-names:`` count to the message.
@@ -505,6 +510,20 @@ def _literalize_errors_as_directive_errors() -> Generator[None]:
         yield
     except ParameterCountMismatchError:
         raise
+    except ParseError as exc:
+        message = str(object=exc)
+        # ``line`` and ``column`` are the underlying parser's one-based
+        # position, set as a pair when the parser supplies one (a
+        # position-less parse failure -- e.g. a duplicate JSON key -- has
+        # neither).  The directive's document and line stay the reported
+        # location; the parser position is appended so an author of a
+        # large data file is not left bisecting it by hand.
+        if exc.line is not None:
+            message = (
+                f"{message} (at line {exc.line}, column {exc.column} "
+                "of the data file)"
+            )
+        raise _DirectiveError(message=message) from exc
     except LiteralizerError as exc:
         message = str(object=exc)
         # ``path`` locates the offending value within the input data

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -9953,6 +9953,93 @@ def test_error_reports_input_path(
     app.cleanup()
 
 
+def test_parse_error_reports_position(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A malformed data file reports the parser's line and column.
+
+    literalizer attaches the underlying parser's one-based position to
+    its parse errors; the directive error appends it so the author of a
+    large data file can jump to the offending line rather than bisecting
+    the input by hand.  The directive's own document and line remain the
+    reported location.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data='{\n  "a": [1, 2,\n}',
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    _assert_directive_error(
+        app=app,
+        source_directory=source_directory,
+        line=4,
+        message=(
+            "Invalid JSON: Expecting value at line 3 column 1 "
+            "(at line 3, column 1 of the data file)"
+        ),
+    )
+    app.cleanup()
+
+
+def test_parse_error_without_position(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A parse error without a parser position reports only its message.
+
+    A duplicate JSON key is rejected by literalizer itself rather than
+    the underlying parser, so the error carries no line or column and no
+    position suffix is appended.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data='{"a": 1, "a": 2}')
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    _assert_directive_error(
+        app=app,
+        source_directory=source_directory,
+        line=4,
+        message="Invalid JSON: duplicate key 'a'",
+    )
+    app.cleanup()
+
+
 def test_error_reports_directive_line(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Closes #397.

A `ParseError` carrying the underlying parser's one-based position now reports it alongside the directive error message:

```
docs/index.rst:4: ERROR: Invalid JSON: Expecting value at line 3 column 1 (at line 3, column 1 of the data file)
```

Decisions on the issue's open questions:

- The directive's document and line stay the reported location; the parser position is appended to the message rather than replacing it, matching how input paths are already reported (`(at input path '...')`).
- The data file's name is not repeated in the suffix: the directive at the reported line already names its data file, and for `literalizer-call` with a `:zip-file:` the failing parse cannot be reliably attributed to one of the two files.
- A position-less parse failure (a duplicate JSON key, an unpaired surrogate) reports only its message; upstream sets `line` and `column` as a pair when the parser supplies one.

Both behaviours are pinned by tests (`test_parse_error_reports_position`, `test_parse_error_without_position`); the input-path half of the issue was already implemented and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to directive error formatting for parse failures; no change to literalization or build flow beyond clearer messages.
> 
> **Overview**
> **Malformed data files** now surface the underlying parser’s one-based line and column in the Sphinx directive error message, appended after the parse error text (same pattern as existing `(at input path '…')` suffixes). The RST document and directive line stay the primary location.
> 
> `_literalize_errors_as_directive_errors` handles `ParseError` before the generic `LiteralizerError` path. When `exc.line` is set, the message gains `(at line N, column M of the data file)`; position-less failures (e.g. duplicate JSON keys) keep the message unchanged.
> 
> Adds a news fragment, `parser's` to the spelling dict, and tests `test_parse_error_reports_position` / `test_parse_error_without_position`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a32b08d9ddcc774a4a61d91fd6ca8906e0f6c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->