### PR TITLE
Drop per-option capability tables for constructor-derived checks

### DIFF
--- a/newsfragments/409.change
+++ b/newsfragments/409.change
@@ -1,0 +1,2 @@
+Unsupported directive options are now reported through literalizer's typed ``UnsupportedOptionError`` instead of hand-maintained per-option capability tables, so adding a language upstream needs no change here.
+Some error messages changed spelling: ``Language 'cpp' does not support ':empty-dict-key:'.`` (previously without colons), and an option value a language does not define is now named, for example ``Language 'python' does not support json-rendering 'inline_document'.``.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -3,6 +3,7 @@ Changelog
 Dhall
 Dhall's
 Fortran
+Haxe
 Initializer
 Jinja
 Jsonnet

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -397,7 +397,7 @@ class _DefaultTypeOption:
 # than relying on the constructor's ``UnsupportedOptionError``) because
 # the ``supports_default_*`` flags are not derivable from constructor
 # field presence: Haxe defines several ``default_*`` fields whose flags
-# are nonetheless ``False`` (adamtheturtle/literalizer#3614).
+# are nonetheless ``False`` (literalizer issue #3614).
 _DEFAULT_TYPE_OPTIONS: dict[str, _DefaultTypeOption] = {
     "default-set-element-type": _DefaultTypeOption(
         param_name="default_set_element_type",

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -41,6 +41,7 @@ from literalizer.exceptions import (
     UnrepresentableEmptyDictError,
     UnrepresentableInputError,
     UnrepresentableIntegerError,
+    UnsupportedOptionError,
 )
 from literalizer.languages import ALL_LANGUAGES
 from sphinx.application import Sphinx
@@ -76,12 +77,20 @@ def _language_name(lang_cls: LanguageCls) -> str:
     return pygments_name
 
 
-def _language_owned_enum(
+def _language_owned_enum_members(
     *, lang_cls: LanguageCls, name: str
-) -> type[enum.Enum]:
-    """Return an enum defined only by a particular language class."""
-    enum_cls: type[enum.Enum] = vars(lang_cls)[name]
-    return enum_cls
+) -> tuple[enum.Enum, ...]:
+    """Return the members of an enum defined only by some language
+    classes.
+
+    A language without the enum contributes no members, so the format
+    lookup tables derive an option's availability from the language
+    class itself rather than a hand-maintained capability table.
+    """
+    enum_cls: type[enum.Enum] | None = vars(lang_cls).get(name)
+    if enum_cls is None:
+        return ()
+    return tuple(enum_cls)
 
 
 @cache
@@ -120,41 +129,19 @@ _FORMAT_OPTION_GETTERS: dict[
     "heterogeneous-strategy": lambda cls: cls.HeterogeneousStrategies,
     "call-style": lambda cls: cls.CallStyles,
     "json-type": lambda cls: cls.JsonTypes,
-    "json-rendering": lambda cls: _language_owned_enum(
+    "json-rendering": lambda cls: _language_owned_enum_members(
         lang_cls=cls,
         name="JsonRenderings",
     ),
     "bool-format": lambda cls: cls.BoolFormats,
-    "annotation-evaluation": lambda cls: _language_owned_enum(
+    "annotation-evaluation": lambda cls: _language_owned_enum_members(
         lang_cls=cls,
         name="AnnotationEvaluations",
     ),
-    "union-format": lambda cls: _language_owned_enum(
+    "union-format": lambda cls: _language_owned_enum_members(
         lang_cls=cls,
         name="UnionFormats",
     ),
-}
-
-
-# Format options whose enum is defined on *every* language but whose
-# constructor keyword only some languages accept.  Membership in the enum
-# (which is all ``_lookup_format`` checks) is therefore not enough to know
-# the option is applicable, so these are gated on a ``supports_*``
-# capability flag -- mirroring :data:`_DEFAULT_TYPE_OPTIONS` -- to raise a
-# clean ``_DirectiveError`` rather than letting an unexpected keyword reach
-# the language constructor as an uncaught ``TypeError``.
-_FORMAT_OPTION_SUPPORTS_CHECKS: dict[str, Callable[[LanguageCls], bool]] = {
-    "empty-dict-key": lambda cls: cls.supports_empty_dict_key,
-    "call-style": lambda cls: cls.supports_call_style,
-    "annotation-evaluation": lambda cls: "AnnotationEvaluations" in vars(cls),
-    "union-format": lambda cls: "UnionFormats" in vars(cls),
-    "json-rendering": lambda cls: "JsonRenderings" in vars(cls),
-}
-
-_FORMAT_OPTION_ENUM_CHECKS: dict[str, Callable[[LanguageCls], bool]] = {
-    "annotation-evaluation": lambda cls: "AnnotationEvaluations" in vars(cls),
-    "union-format": lambda cls: "UnionFormats" in vars(cls),
-    "json-rendering": lambda cls: "JsonRenderings" in vars(cls),
 }
 
 
@@ -173,11 +160,6 @@ def _all_formats() -> dict[str, dict[tuple[str, str], enum.Enum]]:
         option_name: {
             (lang_name, member.name.lower()): member
             for lang_name, lang_cls in _language_types().items()
-            if (
-                (supports_check := _FORMAT_OPTION_ENUM_CHECKS.get(option_name))
-                is None
-                or supports_check(lang_cls)
-            )
             for member in getter(lang_cls)
         }
         for option_name, getter in _FORMAT_OPTION_GETTERS.items()
@@ -411,7 +393,11 @@ class _DefaultTypeOption:
 
 # Default element/key/value type options, lifted to module scope so the
 # typed-options parse boundary and ``_apply_default_type_options`` share
-# one source of truth.
+# one source of truth.  These keep an explicit ``supports_check`` (rather
+# than relying on the constructor's ``UnsupportedOptionError``) because
+# the ``supports_default_*`` flags are not derivable from constructor
+# field presence: Haxe defines several ``default_*`` fields whose flags
+# are nonetheless ``False`` (adamtheturtle/literalizer#3614).
 _DEFAULT_TYPE_OPTIONS: dict[str, _DefaultTypeOption] = {
     "default-set-element-type": _DefaultTypeOption(
         param_name="default_set_element_type",
@@ -436,27 +422,16 @@ _DEFAULT_TYPE_OPTIONS: dict[str, _DefaultTypeOption] = {
 }
 
 
-# Literalizer exposes the same generated heterogeneous carrier concept under
-# language-idiomatic constructor parameter names.
-_HETEROGENEOUS_VALUE_NAME_PARAMETERS: dict[str, str] = {
-    "cpp": "heterogeneous_value_variant_name",
-    "dhall": "heterogeneous_value_union_name",
-    "mojo": "heterogeneous_value_variant_name",
-    "nim": "heterogeneous_value_variant_name",
-    "rust": "heterogeneous_value_enum_name",
-}
-
-
-@cache
-def _languages_supporting_module_name() -> frozenset[str]:
-    """Return directive language keys whose class accepts
-    ``module_name``.
-    """
-    return frozenset(
-        name
-        for name, lang_cls in _language_types().items()
-        if lang_cls.supports_module_name
-    )
+# Literalizer exposes the same generated heterogeneous carrier concept
+# under language-idiomatic constructor parameter names
+# (``..._variant_name`` / ``..._union_name`` / ``..._enum_name``); the
+# name a language accepts is discovered from its constructor fields, so
+# adding a carrier-capable language upstream needs no change here.
+_HETEROGENEOUS_VALUE_NAME_PARAMETERS: tuple[str, ...] = (
+    "heterogeneous_value_variant_name",
+    "heterogeneous_value_union_name",
+    "heterogeneous_value_enum_name",
+)
 
 
 _EXTENSION_TO_INPUT_FORMAT: dict[str, InputFormat] = {
@@ -762,24 +737,12 @@ class _BaseLiteralizerDirective(SphinxDirective):
         value is never the ``auto`` sentinel.
         """
         all_formats = _all_formats()
-        language_cls = _language_types()[language_name]
         for option_name in _FORMAT_OPTION_GETTERS:
             if option_name == "heterogeneous-strategy":
                 value = heterogeneous_strategy_value
             else:
                 value = options.format_options.get(option_name)
             if value is not None:
-                supports_check = _FORMAT_OPTION_SUPPORTS_CHECKS.get(
-                    option_name
-                )
-                if supports_check is not None and not supports_check(
-                    language_cls
-                ):
-                    msg = (
-                        f"Language '{language_name}' does not support "
-                        f"'{option_name}'."
-                    )
-                    raise _DirectiveError(message=msg)
                 param_name = option_name.replace("-", "_")
                 constructor = partial(
                     constructor,
@@ -820,21 +783,19 @@ class _BaseLiteralizerDirective(SphinxDirective):
 
     @staticmethod
     def _apply_multiline_raw_string_delimiter_base(
-        language_name: str,
         constructor: partial[Language],
         *,
         options: _CommonOptions,
     ) -> partial[Language]:
-        """Apply the C++ multiline raw-string delimiter base."""
+        """Apply the multiline raw-string delimiter base option.
+
+        A language whose constructor does not accept the parameter
+        rejects it with ``UnsupportedOptionError``, reported by
+        :meth:`_build_language` as a clean directive error.
+        """
         delimiter_base = options.multiline_raw_string_delimiter_base
         if delimiter_base is None:
             return constructor
-        if language_name != "cpp":
-            msg = (
-                f"Language '{language_name}' does not support "
-                "':multiline-raw-string-delimiter-base:'."
-            )
-            raise _DirectiveError(message=msg)
         return partial(
             constructor,
             multiline_raw_string_delimiter_base=delimiter_base,
@@ -879,14 +840,16 @@ class _BaseLiteralizerDirective(SphinxDirective):
             options=options,
         )
         constructor = self._apply_multiline_raw_string_delimiter_base(
-            language_name=language_name,
             constructor=constructor,
             options=options,
         )
 
         module_name = options.module_name
         if module_name is not None:
-            if language_name not in _languages_supporting_module_name():
+            # ``module_name_case`` exists only on languages that accept
+            # ``module_name``, so this conversion needs a flag check
+            # before the constructor can reject the option itself.
+            if not language_cls.supports_module_name:
                 msg = (
                     f"Language '{language_name}' does not support "
                     f"':module-name:'."
@@ -899,12 +862,6 @@ class _BaseLiteralizerDirective(SphinxDirective):
 
         prefix = options.record_struct_name_prefix
         if prefix is not None:
-            if not language_cls.supports_record_struct_name_prefix:
-                msg = (
-                    f"Language '{language_name}' does not support "
-                    f"':record-struct-name-prefix:'."
-                )
-                raise _DirectiveError(message=msg)
             constructor = partial(
                 constructor,
                 record_struct_name_prefix=prefix,
@@ -912,12 +869,6 @@ class _BaseLiteralizerDirective(SphinxDirective):
 
         shape_names_value = options.record_shape_names
         if shape_names_value is not None:
-            if not language_cls.supports_record_shape_names:
-                msg = (
-                    f"Language '{language_name}' does not support "
-                    f"':record-shape-names:'."
-                )
-                raise _DirectiveError(message=msg)
             constructor = partial(
                 constructor,
                 record_shape_names=_parse_record_shape_names(
@@ -927,8 +878,13 @@ class _BaseLiteralizerDirective(SphinxDirective):
 
         heterogeneous_value_name = options.heterogeneous_value_name
         if heterogeneous_value_name is not None:
-            parameter_name = _HETEROGENEOUS_VALUE_NAME_PARAMETERS.get(
-                language_name,
+            parameter_name = next(
+                (
+                    candidate
+                    for candidate in _HETEROGENEOUS_VALUE_NAME_PARAMETERS
+                    if candidate in language_cls.__dataclass_fields__
+                ),
+                None,
             )
             if parameter_name is None:
                 msg = (
@@ -942,7 +898,18 @@ class _BaseLiteralizerDirective(SphinxDirective):
             )
 
         with _literalize_errors_as_directive_errors():
-            return constructor()
+            try:
+                return constructor()
+            except UnsupportedOptionError as exc:
+                # The constructor is the single authority on which
+                # options a language accepts; translate its error back
+                # into the directive's option spelling.
+                option_name = exc.option.replace("_", "-")
+                msg = (
+                    f"Language '{language_name}' does not support "
+                    f"':{option_name}:'."
+                )
+                raise _DirectiveError(message=msg) from exc
 
     @staticmethod
     def _resolve_format(

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3676,7 +3676,7 @@ def test_empty_dict_key_error(
         app=app,
         source_directory=source_directory,
         line=4,
-        message="Language 'python' does not support 'empty-dict-key'.",
+        message="Language 'python' does not support empty-dict-key 'positional'.",
     )
 
 
@@ -3969,7 +3969,7 @@ def test_unsupported_empty_dict_key_error(
         app=app,
         source_directory=source_directory,
         line=4,
-        message="Language 'cpp' does not support 'empty-dict-key'.",
+        message="Language 'cpp' does not support ':empty-dict-key:'.",
     )
 
 
@@ -4009,7 +4009,7 @@ def test_unsupported_call_style_error(
         app=app,
         source_directory=source_directory,
         line=4,
-        message="Language 'forth' does not support 'call-style'.",
+        message="Language 'forth' does not support ':call-style:'.",
     )
 
 
@@ -9856,7 +9856,10 @@ def test_json_rendering_rejected_for_unsupported_language(
         app=app,
         source_directory=source_directory,
         line=4,
-        message="Language 'python' does not support 'json-rendering'.",
+        message=(
+            "Language 'python' does not support json-rendering "
+            "'inline_document'."
+        ),
     )
     app.cleanup()
 


### PR DESCRIPTION
Closes #396.

literalizer's constructor now rejects an option another language accepts with a typed `UnsupportedOptionError` (adamtheturtle/literalizer#3592, released in 2026.08.12.4), so the extension no longer duplicates per-language constructor signatures:

- `_FORMAT_OPTION_SUPPORTS_CHECKS` and `_FORMAT_OPTION_ENUM_CHECKS` are gone. Language-owned enums (`AnnotationEvaluations`, `UnionFormats`, `JsonRenderings`) contribute no members to the format tables for languages without them, so those options fail through the existing value-lookup message.
- The `:record-struct-name-prefix:`, `:record-shape-names:`, and C++-only `:multiline-raw-string-delimiter-base:` gates are gone. The constructor's `UnsupportedOptionError` is translated back into the directive's option spelling at one site in `_build_language`, producing the same `Language 'x' does not support ':option:'.` messages as before.
- `_HETEROGENEOUS_VALUE_NAME_PARAMETERS` is now a candidate list resolved against the language's constructor fields instead of a hand-written language→parameter map, so a new carrier-capable language upstream needs no change here.
- `_languages_supporting_module_name()` collapses to the existing `supports_module_name` flag. This one stays a pre-check because `module_name_case` only exists on supporting languages and the option value is case-converted before construction.
- `_DEFAULT_TYPE_OPTIONS` keeps its `supports_check`: Haxe defines `default_*` constructor fields whose `supports_default_*` flags are `False`, so field presence cannot stand in for those flags (filed as adamtheturtle/literalizer#3614; the gates can go once that is resolved).

Deliberate message changes, per the issue's "worth keeping whichever gates produce a materially better message" note:

- `Language 'cpp' does not support 'empty-dict-key'.` → `... ':empty-dict-key:'.` (likewise `:call-style:`), unifying on the colon spelling the other options already used.
- `Language 'python' does not support 'empty-dict-key'.` → `... does not support empty-dict-key 'positional'.` — Python lacks that enum value, so the value-lookup message now names it.
- `Language 'python' does not support 'json-rendering'.` → `... does not support json-rendering 'inline_document'.`

Net −87 lines in the extension; 235 tests pass at 100% branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how every directive builds language instances and changes some error messages, but behavior is intended to stay equivalent aside from documented message tweaks; default-type and module-name gates remain for known edge cases.
> 
> **Overview**
> **Delegates unsupported directive options to literalizer** instead of duplicating per-language capability tables in the Sphinx extension.
> 
> The extension drops `_FORMAT_OPTION_SUPPORTS_CHECKS` and `_FORMAT_OPTION_ENUM_CHECKS`, and stops pre-gating options like `:record-struct-name-prefix:`, `:record-shape-names:`, and `:multiline-raw-string-delimiter-base:` before construction. **`_build_language`** now catches literalizer's **`UnsupportedOptionError`** and rewrites it as `Language 'x' does not support ':option:'.` Format lookup for language-owned enums (`JsonRenderings`, etc.) uses **`_language_owned_enum_members`**, so languages without that enum contribute no values and invalid choices surface through the existing value-lookup messages.
> 
> **`:heterogeneous-value-name:`** resolves the constructor parameter by scanning candidate field names on the language dataclass instead of a fixed language→name map. **`:module-name:`** and **`_DEFAULT_TYPE_OPTIONS`** still use explicit `supports_*` checks (module name case conversion and Haxe's `default_*` fields vs flags).
> 
> User-visible error text changes slightly in a few cases (colon-wrapped option names, naming unsupported enum values such as `empty-dict-key 'positional'`). A newsfragment documents the behavior; tests and spelling (`Haxe`) are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd526ca4ec8086a21bcf5883fc24e432acda5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->