### PR TITLE
Bump literalizer to 2026.8.13

### DIFF
--- a/newsfragments/410.change
+++ b/newsfragments/410.change
@@ -1,0 +1,2 @@
+Bump ``literalizer`` to 2026.8.13.
+Record lists in Go, Java, and Kotlin now declare the record element type instead of a top type -- for example ``[]Record0{``, ``new Record0[]{``, and ``listOf<Record0>(`` -- and the Lua signed 64-bit minimum renders as ``math.mininteger`` rather than a decimal literal that overflowed to a float.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.12.5",
+    "literalizer==2026.8.13",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -7605,62 +7605,174 @@ def test_heterogeneous_strategy_record_go(
 
 
 @pytest.mark.parametrize(
-    argnames=("language", "record_declaration", "nested_map_literal"),
+    argnames=("language", "expected_output"),
     argvalues=[
         (
             "csharp",
             (
-                "record Record0(string Name, Dictionary<string, object> "
-                "Input, Dictionary<string, object> Expected);"
+                "using System.Collections.Generic;\n"
+                "record Record0(string Name, "
+                "Dictionary<string, object> Input, "
+                "Dictionary<string, object> Expected);\n"
+                "\n"
+                "new[] {\n"
+                '    new Record0("test_1", '
+                'new Dictionary<string, object> {["type"] = "create", '
+                '["pr_id"] = "pr_1", ["draft"] = true}, '
+                'new Dictionary<string, object> {["pr_id"] = "pr_1", '
+                '["status"] = "draft"}),\n'
+                '    new Record0("test_2", '
+                'new Dictionary<string, object> {["type"] = "publish", '
+                '["pr_id"] = "pr_1"}, '
+                "new Dictionary<string, object> "
+                '{["error"] = "invalid_operation"})\n'
+                "}"
             ),
-            "new Dictionary<string, object>",
         ),
         (
             "cpp",
             (
+                "#include <initializer_list>\n"
+                "#include <string>\n"
+                "#include <map>\n"
+                "#include <vector>\n"
+                "#include <variant>\n"
+                "using LiteralizerRecordValue = "
+                "std::variant<std::string, bool>;\n"
                 "struct Record0 { std::string name; "
                 "std::map<std::string, LiteralizerRecordValue> input; "
-                "std::map<std::string, LiteralizerRecordValue> expected; "
-                "};"
+                "std::map<std::string, LiteralizerRecordValue> expected; };\n"
+                "\n"
+                "std::vector{\n"
+                '    Record0{.name = "test_1", '
+                ".input = std::map<std::string, LiteralizerRecordValue>"
+                '{{"type", LiteralizerRecordValue{"create"}}, '
+                '{"pr_id", LiteralizerRecordValue{"pr_1"}}, '
+                '{"draft", LiteralizerRecordValue{true}}}, '
+                ".expected = std::map<std::string, LiteralizerRecordValue>"
+                '{{"pr_id", LiteralizerRecordValue{"pr_1"}}, '
+                '{"status", LiteralizerRecordValue{"draft"}}}},\n'
+                '    Record0{.name = "test_2", '
+                ".input = std::map<std::string, LiteralizerRecordValue>"
+                '{{"type", LiteralizerRecordValue{"publish"}}, '
+                '{"pr_id", LiteralizerRecordValue{"pr_1"}}}, '
+                ".expected = std::map<std::string, LiteralizerRecordValue>"
+                '{{"error", LiteralizerRecordValue{"invalid_operation"}}}},\n'
+                "}"
             ),
-            "std::map<std::string, LiteralizerRecordValue>",
         ),
-        ("go", "type Record0 struct {", "map[string]any"),
+        (
+            "go",
+            (
+                "package main\n"
+                "type Record0 struct {\n"
+                "\tName string\n"
+                "\tInput map[string]any\n"
+                "\tExpected map[string]any\n"
+                "}\n"
+                "\n"
+                "[]Record0{\n"
+                '\tRecord0{Name: "test_1", '
+                'Input: map[string]any{"type": "create", "pr_id": "pr_1", '
+                '"draft": true}, '
+                'Expected: map[string]any{"pr_id": "pr_1", '
+                '"status": "draft"}},\n'
+                '\tRecord0{Name: "test_2", '
+                'Input: map[string]any{"type": "publish", "pr_id": "pr_1"}, '
+                'Expected: map[string]any{"error": "invalid_operation"}},\n'
+                "}"
+            ),
+        ),
         (
             "java",
             (
-                "record Record0(String name, java.util.Map<String, Object> "
-                "input, java.util.Map<String, Object> expected) {}"
+                "import java.util.Map;\n"
+                "record Record0(String name, "
+                "java.util.Map<String, Object> input, "
+                "java.util.Map<String, Object> expected) {}\n"
+                "\n"
+                "new Record0[]{\n"
+                '    new Record0("test_1", '
+                'Map.ofEntries(Map.entry("type", "create"), '
+                'Map.entry("pr_id", "pr_1"), Map.entry("draft", true)), '
+                'Map.ofEntries(Map.entry("pr_id", "pr_1"), '
+                'Map.entry("status", "draft"))),\n'
+                '    new Record0("test_2", '
+                'Map.ofEntries(Map.entry("type", "publish"), '
+                'Map.entry("pr_id", "pr_1")), '
+                'Map.ofEntries(Map.entry("error", "invalid_operation")))\n'
+                "}"
             ),
-            "Map.ofEntries",
         ),
         (
             "kotlin",
             (
                 "data class Record0(val name: String, "
                 "val input: Map<String, Any?>, "
-                "val expected: Map<String, Any?>)"
+                "val expected: Map<String, Any?>)\n"
+                "\n"
+                "listOf<Record0>(\n"
+                '    Record0(name = "test_1", '
+                'input = mapOf<String, Any?>("type" to "create", '
+                '"pr_id" to "pr_1", "draft" to true), '
+                'expected = mapOf<String, Any?>("pr_id" to "pr_1", '
+                '"status" to "draft")),\n'
+                '    Record0(name = "test_2", '
+                'input = mapOf<String, Any?>("type" to "publish", '
+                '"pr_id" to "pr_1"), '
+                "expected = mapOf<String, Any?>"
+                '("error" to "invalid_operation")),\n'
+                ")"
             ),
-            "mapOf<String, Any?>",
         ),
         (
             "rust",
             (
+                "use std::collections::HashMap;\n"
+                "enum Value {\n"
+                "    Str(&'static str),\n"
+                "    Bool(bool),\n"
+                "}\n"
                 "struct Record0 {\n"
                 "    name: &'static str,\n"
                 "    input: HashMap<&'static str, Value>,\n"
                 "    expected: HashMap<&'static str, Value>,\n"
-                "}"
+                "}\n"
+                "\n"
+                "vec![\n"
+                '    Record0 { name: "test_1", '
+                'input: HashMap::from([("type", Value::Str("create")), '
+                '("pr_id", Value::Str("pr_1")), '
+                '("draft", Value::Bool(true))]), '
+                'expected: HashMap::from([("pr_id", Value::Str("pr_1")), '
+                '("status", Value::Str("draft"))]) },\n'
+                '    Record0 { name: "test_2", '
+                'input: HashMap::from([("type", Value::Str("publish")), '
+                '("pr_id", Value::Str("pr_1"))]), '
+                "expected: HashMap::from("
+                '[("error", Value::Str("invalid_operation"))]) },\n'
+                "]"
             ),
-            "HashMap::from",
         ),
         (
             "scala",
             (
                 "case class Record0(name: String, input: Map[String, Any], "
-                "expected: Map[String, Any])"
+                "expected: Map[String, Any])\n"
+                "\n"
+                "List(\n"
+                '    Record0(name = "test_1", '
+                'input = Map[String, Any]("type" -> "create", '
+                '"pr_id" -> "pr_1", "draft" -> true), '
+                'expected = Map[String, Any]("pr_id" -> "pr_1", '
+                '"status" -> "draft")),\n'
+                '    Record0(name = "test_2", '
+                'input = Map[String, Any]("type" -> "publish", '
+                '"pr_id" -> "pr_1"), '
+                'expected = Map[String, Any]("error" -> "invalid_operation")),'
+                "\n"
+                ")"
             ),
-            "Map[String, Any]",
         ),
     ],
 )
@@ -7669,8 +7781,7 @@ def test_record_nested_map_fallback(
     make_app: Callable[..., SphinxTestApp],
     tmp_path: Path,
     language: str,
-    record_declaration: str,
-    nested_map_literal: str,
+    expected_output: str,
 ) -> None:
     """Record rendering keeps one outer shape and falls back to maps
     for incompatible nested sibling shapes in statically typed targets.
@@ -7723,14 +7834,7 @@ def test_record_nested_map_fallback(
     doctree = app.env.get_doctree(docname="index")
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
     output = literal_block.astext()
-    assert record_declaration in output
-    assert output.count("Record0") == 3
-    assert "Record1" not in output
-    assert nested_map_literal in output
-    assert all(
-        value in output
-        for value in ("test_1", "test_2", "draft", "invalid_operation")
-    )
+    assert output == expected_output
     app.cleanup()
 
 
@@ -8252,7 +8356,7 @@ def test_record_shape_names_java(
         "import java.util.Map;\n"
         "record Point(int x, int y) {}\n"
         "\n"
-        "new Object[]{\n"
+        "new Point[]{\n"
         "    new Point(1, 2),\n"
         "    new Point(3, 4)\n"
         "}"
@@ -8502,7 +8606,7 @@ def test_record_shape_names_trailing_separator_ignored(
         "import java.util.Map;\n"
         "record Point(int x, int y) {}\n"
         "\n"
-        "new Object[]{\n"
+        "new Point[]{\n"
         "    new Point(1, 2),\n"
         "    new Point(3, 4)\n"
         "}"

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.12.5"
+version = "2026.8.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/3d/ecfef83d11d6a91f686c75a77c73eff3e31c887766675e70541b24aa0f13/literalizer-2026.8.12.5.tar.gz", hash = "sha256:b8c91ca131148fb3821c86f0e22bb8e9062979decff1a6d39ae0cf78d3b003da", size = 4068013, upload-time = "2026-08-12T23:21:55.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/04/398f4e8552b32d0d3eb4000ad15bc9d001341098dc70b4a2f802f5e5815c/literalizer-2026.8.13.tar.gz", hash = "sha256:9d293a590bafa1bc23cea804f5d7ffeeacd3fb3ee74d2dc2ac318feb653c6b0c", size = 4066529, upload-time = "2026-08-13T09:11:48.327Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/70/8650f105a32f3da7354e6d10127c3ba046cfbd65e873c6be9b2d54c3a761/literalizer-2026.8.12.5-py3-none-any.whl", hash = "sha256:b687558c01109f8c30b48d545866272b035a1752b849ab8238563c248ed51907", size = 885309, upload-time = "2026-08-12T23:21:54.041Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/90/469af54770e6dcf1f534c22a6e665a60ad3b8d75015920df080e564a6f0c/literalizer-2026.8.13-py3-none-any.whl", hash = "sha256:a36b842b1432e3289e4e17155618815eb59233a0859b35425095d6becca7d593", size = 892169, upload-time = "2026-08-13T09:11:46.409Z" },
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.12.5" },
+    { name = "literalizer", specifier = "==2026.8.13" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Bump `literalizer` to 2026.8.13.

Record lists in Go, Java, and Kotlin now declare the narrowed record element type instead of a top type, so the test expectations were updated: `[]Record0{`, `new Record0[]{`, and `listOf<Record0>(` replace `[]any{`, `new Object[]{`, and `listOf<Any?>(`.

`test_record_nested_map_fallback` now asserts the full expected output per language rather than a set of substring and occurrence-count checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and test-only expectation updates; no application logic changes in this repo.
> 
> **Overview**
> **Bumps the `literalizer` dependency** from `2026.8.12.5` to `2026.8.13` in `pyproject.toml` and `uv.lock`, with a matching `newsfragments/410.change` entry.
> 
> **Test expectations** are aligned with upstream literalizer output: Java record arrays now use `new Point[]` / `new Record0[]` instead of `new Object[]`, and Go/Java/Kotlin record lists use element-typed forms (`[]Record0{`, `new Record0[]{`, `listOf<Record0>(`). The newsfragment also notes Lua signed 64-bit minimum rendering as `math.mininteger` (no test diff shown for that in this PR).
> 
> **`test_record_nested_map_fallback`** is tightened: parametrization supplies a single full `expected_output` string per language (C#, C++, Go, Java, Kotlin, Rust, Scala) and the test asserts exact equality instead of substring and `Record0` count checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2ec6f31498fad981a4ff82cea8b5a6042eae266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->