### PR TITLE
Expose the RECORD widened-map value typing as a directive option

### DIFF
--- a/docs/source/_examples/record_map_value_typing.json
+++ b/docs/source/_examples/record_map_value_typing.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "row_1",
+    "attributes": {"region": "emea", "tier": "gold"}
+  },
+  {
+    "name": "row_2",
+    "attributes": {"region": "apac", "zone": "z1"}
+  }
+]

--- a/docs/source/heterogeneous-strategies.rst
+++ b/docs/source/heterogeneous-strategies.rst
@@ -220,6 +220,52 @@ Scala.  For example, Rust remains standard-library-only:
       :include-delimiters:
       :include-preamble:
 
+Stable fallback map typing (Rust)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default that fallback map's value type follows the data: when every
+widened scalar in the input shares one type, that concrete type is
+spelled.
+This is the tightest type the input admits, but it is derived per input
+file, so two files sharing one record shape can declare the field
+differently.
+With :file:`_examples/record_map_value_typing.json`, where the two
+``attributes`` maps have different keys and so are widened:
+
+.. literalinclude:: _examples/record_map_value_typing.json
+   :language: json
+
+the ``attributes`` values are all strings, so the field is a
+``HashMap<&'static str, &'static str>``:
+
+.. rest-example::
+
+   .. literalizer:: _examples/record_map_value_typing.json
+      :language: rust
+      :heterogeneous-strategy: record
+      :record-shape-names: name,attributes=Row
+      :include-preamble:
+
+``:record-map-value-typing: wide`` instead always spells the strategy's
+value carrier, however uniform this file's scalars happen to be:
+
+.. rest-example::
+
+   .. literalizer:: _examples/record_map_value_typing.json
+      :language: rust
+      :heterogeneous-strategy: record
+      :record-shape-names: name,attributes=Row
+      :record-map-value-typing: wide
+      :include-preamble:
+
+Write one directive per data file with the same
+``:record-map-value-typing: wide``, and every directive declares
+``Row``'s ``attributes`` field identically, so one file's literals
+compile against another file's ``struct``.
+The carrier's own member set stays data-derived, so a file whose widened
+values span more types still declares more variants.
+The option is available for C++, Go, and Rust.
+
 ``tuple`` (Rust)
 ~~~~~~~~~~~~~~~~
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -152,6 +152,20 @@ Directive options
    as ``std::vector<Task>{...}``.  Available for C++, Go, Java, Kotlin,
    Rust, and Scala; using it with any other language raises an error.
 
+``:record-map-value-typing:`` (optional)
+   Value type for a ``:heterogeneous-strategy: record`` field whose dict
+   has no record shape of its own and so renders as a plain map.
+   ``narrow`` (the default) spells the concrete type every widened
+   scalar in this input shares, falling back to the generated carrier
+   type when they span more than one type.  ``wide`` always spells the
+   carrier type -- ``HashMap<&'static str, Value>``,
+   ``map[string]any``, or
+   ``std::map<std::string, LiteralizerRecordValue>`` -- so two data
+   files sharing one record shape declare the field identically and one
+   file's literals compile against the other file's declaration.
+   Available for C++, Go, and Rust; using it with any other language
+   raises an error.  See :doc:`heterogeneous-strategies`.
+
 ``:record-null-substitutions:`` (optional)
    A JSON object mapping record field names to values that replace source
    ``null`` values in those fields. The substitutions are language-neutral

--- a/newsfragments/413.change
+++ b/newsfragments/413.change
@@ -1,0 +1,4 @@
+Bump ``literalizer`` to 2026.8.13.1.
+C++ record literals no longer repeat the ``std::map<...>`` type before a field's map initializer, and a Java text block now spells an indented line's leading spaces as ``\s`` escapes so the text block's incidental-whitespace stripping does not eat them.
+
+The new ``:record-map-value-typing:`` option (C++, Go, and Rust) pins the value type of a ``:heterogeneous-strategy: record`` field whose dict has no record shape of its own and so renders as a plain map: ``:record-map-value-typing: wide`` always spells the strategy's value carrier -- ``HashMap<&'static str, Value>``, ``map[string]any``, or ``std::map<std::string, LiteralizerRecordValue>`` -- so two directives over different data files declare the field identically instead of deriving it per input file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.13",
+    "literalizer==2026.8.13.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -57,6 +57,7 @@ frozenset
 getter
 honoured
 honours
+initializer
 iso
 iterable
 json

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -133,6 +133,14 @@ _FORMAT_OPTION_GETTERS: dict[
         lang_cls=cls,
         name="JsonRenderings",
     ),
+    # ``RecordMapValueTypings`` is shared by the languages that define
+    # the option rather than nested in each of their class bodies, so
+    # the attribute to look for is the lowercase alias rather than the
+    # name of the enum itself.
+    "record-map-value-typing": lambda cls: _language_owned_enum_members(
+        lang_cls=cls,
+        name="record_map_value_typings",
+    ),
     "bool-format": lambda cls: cls.BoolFormats,
     "annotation-evaluation": lambda cls: _language_owned_enum_members(
         lang_cls=cls,
@@ -1198,6 +1206,7 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
            :heterogeneous-strategy: auto
            :json-type: serde_json_value
            :json-rendering: inline_document
+           :record-map-value-typing: wide
            :bool-format: json_pp_ref
            :default-set-element-type: String
            :default-sequence-element-type: String

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3146,7 +3146,9 @@ def test_string_format_multiline_native_delimiters(
     ]
     assert actual == [
         '"""\\\nfirst\n\n  indented\nlast"""',
-        '"""\nfirst\n\n  indented\nlast"""',
+        # A Java text block strips incidental leading whitespace, so the
+        # indented line keeps its spaces as ``\s`` escapes.
+        '"""\nfirst\n\n\\s\\sindented\nlast"""',
         'R"(first\n\n  indented\nlast)"',
         "`first\n\n  indented\nlast`",
         "`first\n\n  indented\nlast`",

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -4,7 +4,7 @@
 import json
 import shutil
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import Mock
@@ -7645,18 +7645,18 @@ def test_heterogeneous_strategy_record_go(
                 "\n"
                 "std::vector{\n"
                 '    Record0{.name = "test_1", '
-                ".input = std::map<std::string, LiteralizerRecordValue>"
+                ".input = "
                 '{{"type", LiteralizerRecordValue{"create"}}, '
                 '{"pr_id", LiteralizerRecordValue{"pr_1"}}, '
                 '{"draft", LiteralizerRecordValue{true}}}, '
-                ".expected = std::map<std::string, LiteralizerRecordValue>"
+                ".expected = "
                 '{{"pr_id", LiteralizerRecordValue{"pr_1"}}, '
                 '{"status", LiteralizerRecordValue{"draft"}}}},\n'
                 '    Record0{.name = "test_2", '
-                ".input = std::map<std::string, LiteralizerRecordValue>"
+                ".input = "
                 '{{"type", LiteralizerRecordValue{"publish"}}, '
                 '{"pr_id", LiteralizerRecordValue{"pr_1"}}}, '
-                ".expected = std::map<std::string, LiteralizerRecordValue>"
+                ".expected = "
                 '{{"error", LiteralizerRecordValue{"invalid_operation"}}}},\n'
                 "}"
             ),
@@ -10006,6 +10006,172 @@ def test_json_rendering_requires_json_type(
         message=(
             "Cpp json_rendering selects how json_type values are "
             "rendered and requires json_type to be set."
+        ),
+    )
+    app.cleanup()
+
+
+def _record_map_value_typing_preamble(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    source_directory: Path,
+    second_row_tier: object,
+    option_lines: str,
+) -> str:
+    """Render a ``RECORD`` document whose ``attributes`` field is widened.
+
+    The two rows' ``attributes`` maps have different keys, so the field
+    cannot become a record of its own and falls back to a plain map.
+    *second_row_tier* varies only the widened values' types, so two
+    calls show whether the declared map value type follows the data.
+    """
+    rows: list[Mapping[str, object]] = [
+        {"name": "row_1", "attributes": {"region": "emea", "zone": "z1"}},
+        {"name": "row_2", "attributes": {"tier": second_row_tier}},
+    ]
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj=rows),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: rust
+           :heterogeneous-strategy: record
+           :record-shape-names: name,attributes=Row
+           :preamble-only:
+        """
+        )
+        + option_lines,
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    preamble = literal_block.astext()
+    app.cleanup()
+    return preamble
+
+
+def test_record_map_value_typing_narrow_is_the_default(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Without the option, the widened map's value type follows the
+    data, so uniform string values give a ``&'static str`` map.
+    """
+    preamble = _record_map_value_typing_preamble(
+        make_app=make_app,
+        source_directory=tmp_path / "source",
+        second_row_tier="gold",
+        option_lines="",
+    )
+
+    assert preamble == (
+        "use std::collections::HashMap;\n"
+        "struct Row {\n"
+        "    name: &'static str,\n"
+        "    attributes: HashMap<&'static str, &'static str>,\n"
+        "}"
+    )
+
+
+def test_record_map_value_typing_wide(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """``:record-map-value-typing: wide`` declares the widened map with
+    the strategy's value carrier, so the field is declared the same way
+    for data whose widened scalars share one type and data whose do not.
+    """
+    uniform_preamble = _record_map_value_typing_preamble(
+        make_app=make_app,
+        source_directory=tmp_path / "uniform",
+        second_row_tier="gold",
+        option_lines="   :record-map-value-typing: wide\n",
+    )
+    mixed_preamble = _record_map_value_typing_preamble(
+        make_app=make_app,
+        source_directory=tmp_path / "mixed",
+        second_row_tier=1,
+        option_lines="   :record-map-value-typing: wide\n",
+    )
+
+    assert uniform_preamble == (
+        "use std::collections::HashMap;\n"
+        "enum Value {\n"
+        "    Str(&'static str),\n"
+        "}\n"
+        "struct Row {\n"
+        "    name: &'static str,\n"
+        "    attributes: HashMap<&'static str, Value>,\n"
+        "}"
+    )
+    assert mixed_preamble == (
+        "use std::collections::HashMap;\n"
+        "enum Value {\n"
+        "    Str(&'static str),\n"
+        "    I32(i32),\n"
+        "}\n"
+        "struct Row {\n"
+        "    name: &'static str,\n"
+        "    attributes: HashMap<&'static str, Value>,\n"
+        "}"
+    )
+
+
+def test_record_map_value_typing_rejected_for_unsupported_language(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A language without a ``RecordMapValueTypings`` enum (e.g. Python)
+    surfaces a clean directive error rather than crashing on the
+    constructor kwarg.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(
+        data=json.dumps(obj={"a": 1}),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :record-map-value-typing: wide
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    _assert_directive_error(
+        app=app,
+        source_directory=source_directory,
+        line=4,
+        message=(
+            "Language 'python' does not support record-map-value-typing "
+            "'wide'."
         ),
     )
     app.cleanup()

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.13"
+version = "2026.8.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/04/398f4e8552b32d0d3eb4000ad15bc9d001341098dc70b4a2f802f5e5815c/literalizer-2026.8.13.tar.gz", hash = "sha256:9d293a590bafa1bc23cea804f5d7ffeeacd3fb3ee74d2dc2ac318feb653c6b0c", size = 4066529, upload-time = "2026-08-13T09:11:48.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/fa/12e52d2963d50bb7cc75a618a28bf1140b3bd965216410c85d0007d023ac/literalizer-2026.8.13.1.tar.gz", hash = "sha256:61200e92f87eb68bb010dbe8fed158111f8989ea8393a73b2c4e147ef82acfa9", size = 4093740, upload-time = "2026-08-13T18:27:56.933Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/90/469af54770e6dcf1f534c22a6e665a60ad3b8d75015920df080e564a6f0c/literalizer-2026.8.13-py3-none-any.whl", hash = "sha256:a36b842b1432e3289e4e17155618815eb59233a0859b35425095d6becca7d593", size = 892169, upload-time = "2026-08-13T09:11:46.409Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/80/faa8ab8fdbb482c62d037229af1f53146b6f5fdb29dbe8c1943949ef9b41/literalizer-2026.8.13.1-py3-none-any.whl", hash = "sha256:e7cab03919f17977f017c267e3c0280228fcf92a58fd488d14ddd63c71f67ecd", size = 895571, upload-time = "2026-08-13T18:27:54.729Z" },
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.13" },
+    { name = "literalizer", specifier = "==2026.8.13.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Closes #411.

Bumps `literalizer` to 2026.8.13.1 and adds `:record-map-value-typing:`, which pins the value type of a `:heterogeneous-strategy: record` field that has no record shape of its own and so falls back to a plain map: `wide` always spells the strategy's value carrier, so two directives over different data files declare the field identically instead of deriving it per input file.

The option is wired through `_FORMAT_OPTION_GETTERS`, so the validator, option spec and constructor-kwarg mapping all pick it up, and it stays rejected with the usual message for a language that does not define the enum -- note the members hang off the lowercase `record_map_value_typings` alias rather than the enum's own name, unlike the nested-class enums behind `:json-rendering:`.

Two rendering changes ride along with the bump and are reflected in the tests: C++ record literals drop the redundant `std::map<...>` prefix before a field's map initializer, and a Java text block now spells an indented line's leading spaces as `\s` escapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Sphinx directive wiring, docs, and test expectations on top of a literalizer release; no auth or runtime service impact.
> 
> **Overview**
> Bumps **`literalizer`** to **2026.8.13.1** and exposes **`:record-map-value-typing:`** on the Sphinx directive for C++, Go, and Rust when a record field falls back to a plain map. **`narrow`** (default) keeps per-file inferred value types; **`wide`** always uses the strategy value carrier so multiple data files can share one struct declaration.
> 
> The option is registered in **`_FORMAT_OPTION_GETTERS`** via the shared **`record_map_value_typings`** enum alias, with docs, an example fixture, and integration tests (default narrow, wide for uniform vs mixed scalars, and a clean error on unsupported languages).
> 
> The dependency bump also updates expected output: C++ record literals no longer repeat **`std::map<...>`** before map initializers, and Java text blocks preserve indented leading spaces as **`\s`** escapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004bdb23d4a5266fd0aaa4c6d3dcff7db00afad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->