### PR TITLE
Bump August dependency releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.13.1",
+    "literalizer==2026.8.16",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -1288,6 +1288,9 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
             options=options,
             both_variable_forms=options.both_variable_forms,
         )
+        # literalizer 2026.8.16+ rejects variable forms without delimiters.
+        if variable_form is not None:
+            include_delimiters = True
         wrap_in_file = options.wrap_in_file
         ref_case, ref_key = self._resolve_ref_options(options=options)
         collection_layout = self._resolve_collection_layout(options=options)

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.13.1"
+version = "2026.8.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/fa/12e52d2963d50bb7cc75a618a28bf1140b3bd965216410c85d0007d023ac/literalizer-2026.8.13.1.tar.gz", hash = "sha256:61200e92f87eb68bb010dbe8fed158111f8989ea8393a73b2c4e147ef82acfa9", size = 4093740, upload-time = "2026-08-13T18:27:56.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/42/b2bf4cc842ef7ff0f1c26fc0842e966b06e27cb48d32ab628fe0b108dc75/literalizer-2026.8.16.tar.gz", hash = "sha256:5af2361c59d70304ecb63ec8bc0ac9c84b803ef64bbbeb6841644f657d777028", size = 4130969, upload-time = "2026-08-16T09:18:16.728Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/80/faa8ab8fdbb482c62d037229af1f53146b6f5fdb29dbe8c1943949ef9b41/literalizer-2026.8.13.1-py3-none-any.whl", hash = "sha256:e7cab03919f17977f017c267e3c0280228fcf92a58fd488d14ddd63c71f67ecd", size = 895571, upload-time = "2026-08-13T18:27:54.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/5150e4b3c41c1ff0f3244d1a19b1b99e726ce1e17d66ea5b5833e0b42104/literalizer-2026.8.16-py3-none-any.whl", hash = "sha256:666b74ce60cb468c36685e44954790cece01dbfbe0912902497e2bfadc48d808", size = 914473, upload-time = "2026-08-16T09:18:15.116Z" },
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.13.1" },
+    { name = "literalizer", specifier = "==2026.8.16" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.7.19.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Updates the newly released internal dependencies to their latest August 2026 versions.\n\nThis keeps the development and test toolchain on the released implementations and refreshes the uv lockfile.\n\nValidation: `uv lock` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and a narrow directive compatibility tweak for variable-form rendering; no auth or security surface.
> 
> **Overview**
> **Bumps `literalizer` from `2026.8.13.1` to `2026.8.16`** in `pyproject.toml` and refreshes `uv.lock`.
> 
> To stay compatible with **literalizer 2026.8.16+**, the `literalizer` directive now **forces `include_delimiters=True`** whenever a variable form is resolved (`:variable-name:` and related options). That matches the library’s new rule that variable forms cannot be rendered without delimiters, so builds do not fail after the upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d3c6c07e0622c93fc640470eba52367846792b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->