### PR TITLE
Document variable-form delimiter enablement

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -316,8 +316,8 @@ Directive options
 
 ``:variable-name:`` (optional)
    Wrap the output in a variable declaration or assignment using the given
-   name.  Use with ``:include-delimiters:`` to include the collection
-   delimiters.
+   name.  Collection delimiters are included automatically when this option
+   is set (literalizer rejects delimiter-less variable forms).
 
 ``:existing-variable:`` (optional flag)
    When combined with ``:variable-name:``, produce an assignment to an

--- a/newsfragments/428.change.rst
+++ b/newsfragments/428.change.rst
@@ -1,0 +1,1 @@
+Document that ``:variable-name:`` implies collection delimiters, matching literalizer 2026.8.16+.

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1130,6 +1130,67 @@ def test_variable_name_python(
     assert content_html == expected_html
 
 
+def test_variable_name_implies_include_delimiters(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """A variable form includes collection delimiters without the flag.
+
+    literalizer 2026.8.16+ rejects delimiter-less variable forms, so the
+    directive enables delimiters whenever ``:variable-name:`` is set.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.json").write_text(data=json.dumps(obj=[1, 2]))
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: data.json
+           :language: python
+           :variable-name: my_list
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. code-block:: python
+
+           my_list = (
+               1,
+               2,
+           )
+    """
+        )
+    )
+    expected_app = make_app(srcdir=source_directory)
+    expected_app.build()
+    assert expected_app.statuscode == 0
+    expected_html = (expected_app.outdir / "index.html").read_text()
+    expected_app.cleanup()
+
+    assert content_html == expected_html
+
+
 def test_dart_language(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
## Summary
- Document that `:variable-name:` automatically includes collection delimiters (literalizer 2026.8.16+).
- Add a regression test covering that behavior without an explicit `:include-delimiters:` flag.

## Test plan
- [x] `pytest tests/test_extension.py::test_variable_name_implies_include_delimiters`
- [ ] CI green

Made with [Cursor](https://cursor.com)