### PR TITLE
Name the data file in every directive error

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -817,12 +817,15 @@ Errors
 
 A directive that cannot render its data -- because of an option the language does not support, an option combination that does not make sense, or data the language cannot represent -- reports the failure against its own location::
 
-   docs/index.rst:5: ERROR: Language 'python' does not support sequence-format 'vec'.
+   docs/index.rst:5: ERROR: Language 'python' does not support sequence-format 'vec'. (in 'data.json')
 
 Such an error does not stop the build, so one run reports every failing block rather than only the first.
 Build with ``-W`` to turn these errors into a build failure.
 
-When an error concerns one particular value in the data file, the message ends with that value's input path -- for example ``(at input path 'tasks[0].items')`` -- so the offending value can be found without searching the whole file.
+Every such message ends with the data file the directive names, written as the directive writes it.
+That matters when a directive is generated inside another directive's content -- a ``sphinx-jinja2`` block, say -- because the reported line is then the enclosing directive's rather than the generated one's, and the data file is what identifies the block that failed.
+
+When an error concerns one particular value in the data file, the message also carries that value's input path -- for example ``(at input path 'tasks[0].items')`` -- so the offending value can be found without searching the whole file.
 
 Problems that are not attributable to a directive, such as an invalid value for one of the configuration settings below, still fail the build immediately.
 

--- a/newsfragments/442.change.rst
+++ b/newsfragments/442.change.rst
@@ -1,0 +1,1 @@
+Directive errors now end with the data file the directive names, for example ``(in 'calls.yaml')``.

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -656,11 +656,21 @@ class _BaseLiteralizerDirective(SphinxDirective):
         is reported as ``document.rst:<line>: ERROR: <message>`` against
         the offending directive, participates in ``-W``, and lets one
         build surface every bad block instead of aborting at the first.
+
+        The message ends with the data file the directive names.  A
+        directive generated inside another directive's content -- a
+        ``sphinx-jinja2`` block, say -- is reported against the
+        *enclosing* directive's line, so the document and line alone
+        identify neither the failing directive nor its input; the data
+        file is what an author has to open to fix the error, and within
+        one generated block it identifies the directive too.
         """
         try:
             return self._run()
         except _DirectiveError as exc:
-            raise self.error(message=str(object=exc)) from exc
+            data_file = self.arguments[0]
+            message = f"{exc} (in '{data_file}')"
+            raise self.error(message=message) from exc
 
     def _run(self) -> list[nodes.Node]:  # pragma: no cover
         """Produce the nodes for this directive."""
@@ -906,7 +916,11 @@ class _BaseLiteralizerDirective(SphinxDirective):
         extension.
 
         *option_name* names the directive option that *explicit* came
-        from, used only for the "cannot determine" error message.
+        from, used only for the "cannot determine" error message.  It is
+        what identifies *which* file could not be resolved: every
+        directive error already ends with the directive's data file, so
+        naming the file here as well would repeat it for the common case
+        of the data file's own format.
         """
         if explicit is not None:
             return _enum_member(cls=InputFormat, value=explicit)
@@ -915,7 +929,7 @@ class _BaseLiteralizerDirective(SphinxDirective):
             return _EXTENSION_TO_INPUT_FORMAT[suffix]
         except KeyError:
             msg = (
-                f"Cannot determine input format for '{data_path.name}'. "
+                "Cannot determine input format from the file extension. "
                 f"Use the :{option_name}: option."
             )
             raise _DirectiveError(message=msg) from None

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -28,10 +28,19 @@ def _assert_directive_error(
     The error is expected against ``index.rst`` at *line* -- the first
     line of the offending directive -- so an author can find the block
     that failed without searching the document for it.
+
+    Every directive error also ends with the data file the directive
+    names, so the expectation is completed from the argument written on
+    *line* rather than repeated in *message* at every call site.
     """
     app.build()
     document = source_directory / "index.rst"
-    expected = f"{document}:{line}: ERROR: {message} [docutils]"
+    directive = document.read_text(encoding="utf-8").splitlines()[line - 1]
+    _, data_file = directive.split(sep="::", maxsplit=1)
+    expected = (
+        f"{document}:{line}: ERROR: {message} "
+        f"(in '{data_file.strip()}') [docutils]"
+    )
     reported = strip_colors(app.warning.getvalue()).splitlines()
     assert reported == [expected]
 
@@ -4639,7 +4648,7 @@ def test_unknown_extension_without_input_format_errors(
         source_directory=source_directory,
         line=4,
         message=(
-            "Cannot determine input format for 'data.dat'. "
+            "Cannot determine input format from the file extension. "
             "Use the :input-format: option."
         ),
     )
@@ -10465,11 +10474,70 @@ def test_errors_do_not_stop_the_build(
     assert reported == [
         (
             f"{document}:4: ERROR: Language 'python' does not support "
-            "sequence-format 'vec'. [docutils]"
+            "sequence-format 'vec'. (in 'data.json') [docutils]"
         ),
         (
             f"{document}:8: ERROR: Language 'rust' does not support "
-            "set-format 'frozenset'. [docutils]"
+            "set-format 'frozenset'. (in 'data.json') [docutils]"
+        ),
+    ]
+    app.cleanup()
+
+
+def test_error_names_the_data_file(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+) -> None:
+    """Every directive error ends with the data file the directive read.
+
+    A directive generated inside another directive's content -- a
+    ``sphinx-jinja2`` block, say -- is reported against the enclosing
+    directive's line, so identical failures over different data files
+    would otherwise be indistinguishable.  The path is echoed as the
+    directive writes it, which is what an author has to open.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "first.json").write_text(data=json.dumps(obj=[1]))
+    nested_directory = source_directory / "nested"
+    nested_directory.mkdir()
+    (nested_directory / "second.json").write_text(data=json.dumps(obj=[2]))
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+        Test
+        ====
+
+        .. literalizer:: first.json
+           :language: python
+           :sequence-format: vec
+
+        .. literalizer:: nested/second.json
+           :language: python
+           :sequence-format: vec
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    document = source_directory / "index.rst"
+    reported = strip_colors(app.warning.getvalue()).splitlines()
+    assert reported == [
+        (
+            f"{document}:4: ERROR: Language 'python' does not support "
+            "sequence-format 'vec'. (in 'first.json') [docutils]"
+        ),
+        (
+            f"{document}:8: ERROR: Language 'python' does not support "
+            "sequence-format 'vec'. (in 'nested/second.json') [docutils]"
         ),
     ]
     app.cleanup()
@@ -10511,7 +10579,7 @@ def test_errors_fail_the_build_with_warnings_as_errors(
     assert reported == [
         (
             f"{document}:4: ERROR: Language 'python' does not support "
-            "sequence-format 'vec'. [docutils]"
+            "sequence-format 'vec'. (in 'data.json') [docutils]"
         )
     ]
     app.cleanup()


### PR DESCRIPTION
Closes #439.

Directive errors now end with the data file the directive names, written as the directive writes it:

```
docs/index.rst:5: ERROR: Language 'python' does not support sequence-format 'vec'. (in 'data.json')
```

A directive generated inside another directive's content — a `sphinx-jinja2` block, say — is reported against the *enclosing* directive's line, so the document and line identify neither the failing directive nor its input.
The data file is the thing an author has to open, and within one generated block it identifies the directive in practice.

`Cannot determine input format ...` no longer names the file itself, since the suffix does that; the option it names (`:input-format:` vs `:zip-input-format:`) is what says *which* file could not be resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFEKs5FqzZgtdsnH2TfXPk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing Sphinx warning text only; no change to literalization behavior or build success semantics beyond clearer messages.
> 
> **Overview**
> **Directive errors** now end with the data file argument as written on the directive, e.g. `(in 'data.json')`, so authors can tell which input failed—especially when directives are emitted from templates like **sphinx-jinja2**, where the reported line may belong to the enclosing block rather than the failing `literalizer` call.
> 
> The **“cannot determine input format”** message no longer repeats the filename (the new suffix already identifies the main data file); it points at the relevant option (`:input-format:` vs `:zip-input-format:`) instead.
> 
> Docs, a newsfragment, test helpers, and expectations were updated; **`test_error_names_the_data_file`** covers distinct paths such as `first.json` vs `nested/second.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d3a79b468e525a1f1d23cfc754c769fc82a8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->