### PR TITLE
Cover input-file comments in rendered output

### DIFF
--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -2818,8 +2818,8 @@ def test_element_comments_label_their_own_element(
     """A comment before an element is rendered before that element.
 
     Comments in the data file are the labels an author writes for each
-    element, so a comment that slides onto the neighbouring element --
-    or is dropped -- silently mislabels the rendered block.  Both
+    element, so a comment that slides onto another element -- or is
+    dropped -- silently mislabels the rendered block.  Both
     collection layouts are covered because an element that renders
     across several lines is where that has gone wrong before.
     """

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -2763,6 +2763,209 @@ def test_comment_format_block(
     assert slash_html != block_html
 
 
+@pytest.mark.parametrize(
+    argnames=("collection_layout", "expected"),
+    argvalues=[
+        (
+            "compact",
+            """\
+(
+    # first case
+    ({"a": 1, "b": 2}, "x"),
+    # second case
+    ({"a": 3}, "y"),
+    # third case
+    ({"a": 4}, "z"),
+)""",
+        ),
+        (
+            "multiline",
+            """\
+(
+    # first case
+    (
+        {
+            "a": 1,
+            "b": 2,
+        },
+        "x",
+    ),
+    # second case
+    (
+        {
+            "a": 3,
+        },
+        "y",
+    ),
+    # third case
+    (
+        {
+            "a": 4,
+        },
+        "z",
+    ),
+)""",
+        ),
+    ],
+)
+def test_element_comments_label_their_own_element(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+    collection_layout: str,
+    expected: str,
+) -> None:
+    """A comment before an element is rendered before that element.
+
+    Comments in the data file are the labels an author writes for each
+    element, so a comment that slides onto the neighbouring element --
+    or is dropped -- silently mislabels the rendered block.  Both
+    collection layouts are covered because an element that renders
+    across several lines is where that has gone wrong before.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(
+        data=dedent(
+            text="""\
+            # first case
+            - - a: 1
+                b: 2
+              - x
+
+            # second case
+            - - a: 3
+              - y
+
+            # third case
+            - - a: 4
+              - z
+        """
+        )
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text=f"""\
+        Test
+        ====
+
+        .. literalizer:: data.yaml
+           :language: python
+           :include-delimiters:
+           :collection-layout: {collection_layout}
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == expected
+    app.cleanup()
+
+
+@pytest.mark.parametrize(
+    argnames=("collection_layout", "expected"),
+    argvalues=[
+        (
+            "compact",
+            """\
+# first case
+check(values={"a": 1, "b": 2}, name="x")
+# second case
+check(values={"a": 3}, name="y")
+# third case
+check(values={"a": 4}, name="z")""",
+        ),
+        (
+            "multiline",
+            """\
+# first case
+check(values={
+    "a": 1,
+    "b": 2,
+}, name="x")
+# second case
+check(values={
+    "a": 3,
+}, name="y")
+# third case
+check(values={
+    "a": 4,
+}, name="z")""",
+        ),
+    ],
+)
+def test_literalizer_call_per_element_element_comments(
+    *,
+    make_app: Callable[..., SphinxTestApp],
+    tmp_path: Path,
+    collection_layout: str,
+    expected: str,
+) -> None:
+    """Each generated call keeps the comment that labels its element.
+
+    ``:per-element:`` is how a data file of test cases becomes one call
+    per case, so a comment landing on the wrong call -- or disappearing
+    after the first -- mislabels the generated calls.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "data.yaml").write_text(
+        data=dedent(
+            text="""\
+            # first case
+            - - a: 1
+                b: 2
+              - x
+
+            # second case
+            - - a: 3
+              - y
+
+            # third case
+            - - a: 4
+              - z
+        """
+        )
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text=f"""\
+        Test
+        ====
+
+        .. literalizer-call:: data.yaml
+           :language: python
+           :target-function: check
+           :parameter-names: values,name
+           :per-element:
+           :collection-layout: {collection_layout}
+    """
+        )
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        confoverrides={"extensions": ["sphinx_literalizer"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+
+    doctree = app.env.get_doctree(docname="index")
+    (literal_block,) = doctree.findall(condition=nodes.literal_block)
+    assert literal_block.astext() == expected
+    app.cleanup()
+
+
 def test_unsupported_comment_format_error(
     *,
     make_app: Callable[..., SphinxTestApp],


### PR DESCRIPTION
Closes #430.

A `literalizer` bump that moves or drops the comments preceding a data file's elements had no rendered-output coverage here, so the 2026.8.12 element-comment regression (adamtheturtle/literalizer#4385) rode through five releases and was only caught downstream.

Adds golden coverage for both directives over the shape that regressed — a YAML sequence whose elements each carry a preceding `#` comment — in both collection layouts, so elements that render across multiple lines are covered too:

- `.. literalizer::` with `:include-delimiters:`
- `.. literalizer-call::` with `:per-element:`

Verified that all four cases fail against `literalizer==2026.8.16` and pass against the pinned `2026.8.23`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFEKs5FqzZgtdsnH2TfXPk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or dependency pin updates in this diff.
> 
> **Overview**
> Adds **regression tests** so a YAML sequence where each item has a leading `#` comment keeps those comments on the right element in the rendered literal block—covering the bug fixed in literalizer 2026.8.23.
> 
> Two parametrized cases exercise **`compact`** and **`multiline`** `collection-layout` for both **`.. literalizer::`** with `:include-delimiters:` and **`.. literalizer-call::`** with `:per-element:`, asserting doctree `literal_block` text matches golden strings (tuple layout vs. generated `check(...)` calls).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8c26f40065a991b926d89a4a4020a87a9d929b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->