### PR TITLE
Bump literalizer to 2026.8.27

### DIFF
--- a/newsfragments/444.change.rst
+++ b/newsfragments/444.change.rst
@@ -1,0 +1,4 @@
+Bump ``literalizer`` to 2026.8.27.
+Generated strings now escape DEL and the other control bytes that YAML, TOML, SML, and Scheme parsers reject.
+Empty list values in maps borrow the element type of a non-empty sibling in C++, Go, and Rust.
+C, C++, and D non-decimal integer formats keep negative values at the signed 32-bit boundary signed instead of wrapping them positive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.23",
+    "literalizer==2026.8.27",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.23"
+version = "2026.8.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/cf/296d71326dae767b11b3fe5d287151e8cc1aebe572f36eb73e5a723aaa73/literalizer-2026.8.23.tar.gz", hash = "sha256:aa3e6532a48edc656710afd12804fea1483d84e2067df54086cf14c1543e1aee", size = 4225182, upload-time = "2026-08-23T14:55:16.984Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/4f/1f77e79727fd4db34532738afd5f90debb74e32333d453393c90e2c4499a/literalizer-2026.8.27.tar.gz", hash = "sha256:85c7ddae79a681751e52f550697083f07bf9a044a2068f510a07daebd0e20130", size = 4274481, upload-time = "2026-08-27T06:09:38.494Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/5a/570e4235c108be64bb9291510674a0ac0a9670549c6f7fb17cd61bb79709/literalizer-2026.8.23-py3-none-any.whl", hash = "sha256:f13f917229ccd62b4f38786129bac7938b9e1a9088d9221bb23a452dac164b6e", size = 936480, upload-time = "2026-08-23T14:55:15.158Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c0/694410d11ffaef90c0e9b809076f4df447e8b361ef69980080a65bf92526/literalizer-2026.8.27-py3-none-any.whl", hash = "sha256:b09c064d707fb5e8a0936251982b2e5c24d64f07d99a05dd9e72b41d1f6b70d4", size = 943426, upload-time = "2026-08-27T06:09:36.061Z" },
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.23" },
+    { name = "literalizer", specifier = "==2026.8.27" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.8.25.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Bumps the pinned `literalizer` from 2026.8.23 to [2026.8.27](https://github.com/adamtheturtle/literalizer/releases/tag/2026.08.27).

User-visible highlights for this extension:

- Generated strings escape DEL and other control bytes that YAML, TOML, SML, and Scheme parsers reject.
- Empty list values in maps borrow the element type of a non-empty sibling in C++, Go, and Rust.
- C, C++, and D non-decimal integer formats keep negative values at the signed 32-bit boundary signed instead of wrapping them positive.

The whole suite passes unchanged against the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFEKs5FqzZgtdsnH2TfXPk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump only; output may differ for edge-case strings and integers but the extension code is unchanged and the suite is reported passing.
> 
> **Overview**
> Pins **`literalizer`** from `2026.8.23` to **`2026.8.27`** in `pyproject.toml` and `uv.lock`, and adds a Towncrier fragment (`newsfragments/444.change.rst`) for the release notes.
> 
> Through that upstream bump, Sphinx-generated literals inherit several **literalizer** fixes: control bytes (including DEL) are escaped so YAML, TOML, SML, and Scheme output parses cleanly; empty list values in maps infer element types from non-empty siblings for C++, Go, and Rust; and C/C++/D non-decimal integers at the signed 32-bit boundary stay negative instead of wrapping positive.
> 
> There are **no changes** to `sphinx_literalizer` itself in this diff—only the dependency pin and changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d973e8dff133b296e0d191312aebc93c9c1ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->