### PR TITLE
Bump literalizer to 2026.8.29.1

### DIFF
--- a/newsfragments/450.change.rst
+++ b/newsfragments/450.change.rst
@@ -1,0 +1,3 @@
+Bump ``literalizer`` to 2026.8.29.1.
+The ``:wrap-in-file:`` option now always includes delimiters, which the new release requires for a wrapped file.
+The map-type import is no longer emitted for a document whose maps are all recordized.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
 dependencies = [
     "beartype==0.22.9",
     "docutils",
-    "literalizer==2026.8.27",
+    "literalizer==2026.8.29.1",
     "sphinx>=7.0",
 ]
 optional-dependencies.dev = [

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -79,6 +79,7 @@ pre
 prepends
 pyright
 rawsource
+recordized
 repr
 representable
 sml

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -71,6 +71,7 @@ multiline
 norg
 overridable
 parser's
+parsers
 php
 positionally
 pragma

--- a/src/sphinx_literalizer/__init__.py
+++ b/src/sphinx_literalizer/__init__.py
@@ -1282,6 +1282,11 @@ class LiteralizerDirective(_BaseLiteralizerDirective):
         if variable_form is not None:
             include_delimiters = True
         wrap_in_file = options.wrap_in_file
+        # literalizer 2026.8.29.1+ rejects a wrapped file without
+        # delimiters, which would present a bare collection fragment as a
+        # complete source file.
+        if wrap_in_file:
+            include_delimiters = True
         ref_case, ref_key = self._resolve_ref_options(options=options)
         collection_layout = self._resolve_collection_layout(options=options)
 

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -8628,7 +8628,6 @@ def test_record_shape_names_java(
     doctree = app.env.get_doctree(docname="index")
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
     assert literal_block.astext() == (
-        "import java.util.Map;\n"
         "record Point(int x, int y) {}\n"
         "\n"
         "new Point[]{\n"
@@ -8686,7 +8685,6 @@ def test_record_shape_names_cpp14_external_record(
     assert output == (
         "#include <initializer_list>\n"
         "#include <string>\n"
-        "#include <map>\n"
         "#include <vector>\n"
         "\n"
         "std::vector<Task>{\n"
@@ -8878,7 +8876,6 @@ def test_record_shape_names_trailing_separator_ignored(
     doctree = app.env.get_doctree(docname="index")
     (literal_block,) = doctree.findall(condition=nodes.literal_block)
     assert literal_block.astext() == (
-        "import java.util.Map;\n"
         "record Point(int x, int y) {}\n"
         "\n"
         "new Point[]{\n"

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ wheels = [
 
 [[package]]
 name = "literalizer"
-version = "2026.8.27"
+version = "2026.8.29.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
@@ -793,9 +793,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/4f/1f77e79727fd4db34532738afd5f90debb74e32333d453393c90e2c4499a/literalizer-2026.8.27.tar.gz", hash = "sha256:85c7ddae79a681751e52f550697083f07bf9a044a2068f510a07daebd0e20130", size = 4274481, upload-time = "2026-08-27T06:09:38.494Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/b1b88e74ad1a52d8be0d69264ab615525bd5714c3a958bd47efe0ea19f91/literalizer-2026.8.29.1.tar.gz", hash = "sha256:e9da80dc2b24d23f4e643125d6e20e713277caa204077e6b5dfe89449d54ea9a", size = 4517799, upload-time = "2026-08-29T08:04:47.364Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/c0/694410d11ffaef90c0e9b809076f4df447e8b361ef69980080a65bf92526/literalizer-2026.8.27-py3-none-any.whl", hash = "sha256:b09c064d707fb5e8a0936251982b2e5c24d64f07d99a05dd9e72b41d1f6b70d4", size = 943426, upload-time = "2026-08-27T06:09:36.061Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/32/aa3079b226dc78716ad54fc7f96089ed75e4428579c706faa9d8db7bf518/literalizer-2026.8.29.1-py3-none-any.whl", hash = "sha256:cf76da3c7efaabec0d350c39ed334a50110f59f41e89687cacd126f5bf268fc8", size = 1008213, upload-time = "2026-08-29T08:04:44.837Z" },
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ requires-dist = [
     { name = "docutils" },
     { name = "furo", marker = "extra == 'dev'", specifier = "==2025.12.19" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
-    { name = "literalizer", specifier = "==2026.8.27" },
+    { name = "literalizer", specifier = "==2026.8.29.1" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.3.1" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.8.25.1" },
     { name = "no-defaults", marker = "extra == 'dev'", specifier = "==2.1.0" },


### PR DESCRIPTION
Bumps `literalizer` from 2026.8.27 to [2026.8.29.1](https://github.com/adamtheturtle/literalizer/releases/tag/2026.08.29.1).

Adaptations to behavior changes in the new release:

- `literalize` now raises `DelimiterlessWrappedFileError` for `include_delimiters=False` with `wrap_in_file=True`, so the directive forces delimiters on under `:wrap-in-file:` — the same shape as the existing variable-form adaptation.
- The map-type import (`import java.util.Map;` / `#include <map>`) is no longer emitted when every map is recordized; three test expectations updated.
- Added `parsers` to the spelling dictionary (pre-existing manual-stage failure on an unchanged changelog line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and small directive flag logic with matching test updates; no auth or data-handling changes.
> 
> **Overview**
> Upgrades **`literalizer`** to **2026.8.29.1** and adjusts the Sphinx directive so builds stay compatible with the new release.
> 
> When **`:wrap-in-file:`** is set, the extension now always passes **`include_delimiters=True`** into literalize (same pattern as variable forms), because the new literalizer rejects wrapped output without delimiters.
> 
> Test expectations drop redundant **map** imports (`java.util.Map`, `#include <map>`) where all maps are recordized—behavior that comes from the bumped dependency. Spelling entries and a newsfragment document the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 625ebf72045f58f60ea63e402a7edfec9604c1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->